### PR TITLE
services should be deployed before objects that create pods

### DIFF
--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -23,6 +23,16 @@ done
 echo "Done deploying Secrets"
 echo ""
 
+echo "Deploying Services"
+for index in "${!SERVICE_FILES[@]}"
+do
+  SERVICE_FILE=${SERVICE_FILES[$index]}
+  echo "Applying ${SERVICE_FILE}"
+  kubectl apply -f ${SERVICE_FILE} --namespace=$NAMESPACE --record
+done
+echo "Done deploying Services"
+echo ""
+
 echo "Deploying Persistent Volumes"
 for index in "${!PERSISTENT_VOLUME_FILES[@]}"
 do
@@ -51,16 +61,6 @@ do
   kubectl apply -f ${STATEFULSET_FILE} --namespace=$NAMESPACE --record
 done
 echo "Done deploying StatefulSets"
-echo ""
-
-echo "Deploying Services"
-for index in "${!SERVICE_FILES[@]}"
-do
-  SERVICE_FILE=${SERVICE_FILES[$index]}
-  echo "Applying ${SERVICE_FILE}"
-  kubectl apply -f ${SERVICE_FILE} --namespace=$NAMESPACE --record
-done
-echo "Done deploying Services"
 echo ""
 
 echo "Deploying Endpoints"


### PR DESCRIPTION
Generally speaking services should be deployed prior to objects that create pods as networking should be established; especially when deploying pods that need to discover one another.

A specific use-case where I needed this:

elasticsearch-discovery service needs to exist before masters launch for peer discovery.

This change in the 'batting-order' is brought to you by .... This won't break anything.