### PR TITLE
add support for deploying `PodDisruptionBudget`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ DEPLOYMENTS=('example-app')
 # List of files ending in '.horizontal_pod_autoscaler.yml' in the kube directory
 HORIZONTAL_POD_AUTOSCALERS=()
 
+# List of files ending in '.pod_disruption_budget.yml' in the kube directory
+POD_DISRUPTION_BUDGETS=()
+
 # List of files ending in '.job.yml' in the kube directory
 JOBS=()
 
@@ -101,6 +104,7 @@ Your kubernetes API object files should all be stored in the /deploy top level d
 * Blocking Jobs end in `blockingjob.yml`
 * Jobs end in `job.yml`
 * Ingress Resources end in `ingress.yml`
+* Pod Disruption Budgets end in `pod_disruption_budget.yml`
 
 ## Commands
 

--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -146,3 +146,12 @@ do
   kubectl apply -f ${HORIZONTAL_POD_AUTOSCALER_FILE} --namespace=$NAMESPACE --record
 done
 echo "Done deploying Horizontal Pod Autoscalers"
+
+echo "Deploying Pod Disruption Budgets"
+for index in "${!POD_DISRUPTION_BUDGET_FILES[@]}"
+do
+  POD_DISRUPTION_BUDGET_FILE=${POD_DISRUPTION_BUDGET_FILES[$index]}
+  echo "Applying ${POD_DISRUPTION_BUDGET_FILE}"
+  kubectl apply -f ${POD_DISRUPTION_BUDGET_FILE} --namespace=$NAMESPACE --record
+done
+echo "Done deploying Pod Disruption Budget"

--- a/bin/k8s-read-config
+++ b/bin/k8s-read-config
@@ -131,6 +131,14 @@ do
 done
 echo "[horizontal_pod_autoscaler_files]: ${HORIZONTAL_POD_AUTOSCALER_FILES[@]}"
 
+echo "[pod_disruption_budget]: ${POD_DISRUPTION_BUDGETS[@]}"
+POD_DISRUPTION_BUDGET_FILES=()
+for i in "${POD_DISRUPTION_BUDGETS[@]}"
+do
+  POD_DISRUPTION_BUDGET_FILES+=($BASEDIR/deploy/$i.pod_disruption_budget.yml)
+done
+echo "[pod_disruption_budget_files]: ${POD_DISRUPTION_BUDGET_FILES[@]}"
+
 echo "[blocking jobs]: ${BLOCKING_JOBS[@]}"
 BLOCKING_JOBS_FILES=()
 for i in "${BLOCKING_JOBS[@]}"


### PR DESCRIPTION
add support for deploying `PodDisruptionBudget` via rok8s-scripts

https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-disruption-budget/

Example spec:

```
$ cat es/es.pod_disruption_budget.yml 
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
  name: es
spec:
  minAvailable: 3
  selector:
    matchLabels:
      component: elasticsearch
      storage: persistent
```