### PR TITLE
readme: Recommend install from NPMjs instead of GH

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Opinionated scripts for managing application development and deployment lifecycl
 ## How to Install
 
 ```
-npm install reactiveops/k8s-scripts
+npm install rok8s-scripts
 export PATH="$(PWD)/node_modules/.bin:$PATH"
 ```
 


### PR DESCRIPTION
This will install the `rok8s-scripts` package from NPMjs. The previous
version would be installed from Github ( org/project notation for NPM).

The packaged version is now automatically released when following the
release process.