### PR TITLE
k8s-lint: Start linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Will exit non-zero on a failure.
 Current checks:
 
 * Files referenced in config file exist (does not check for secrets files)
+* Deployments contain a `revisionHistoryLimit`
 
 ### k8s-secrets-from-s3
 

--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ Combines `k8s-deploy` and `k8s-verify` into a single command. This can be used t
 
 Nukes everything defined in your k8s-scripts config file.
 
+### k8s-lint
+
+Linter to provide quick feedback on files. This should be used as part of your CI testing to lint on each build to discover problems before they stop a deployment.
+
+Example:
+
+```
+k8s-lint -f k8s-scripts.config
+```
+
+Will exit non-zero on a failure.
+
+Current checks:
+
+* Files referenced in config file exist (does not check for secrets files)
+
 ### k8s-secrets-from-s3
 
 Generates a kubernetes secrets YAML file from the contents of a path within an S3 bucket. This will copy files from `${S3_BUCKET}/${NAMESPACE}/${SECRET}` and generate a file into `deploy/${SECRET}.secret.yaml`, suitable for deployment with `k8s-deploy`.

--- a/bin/k8s-lint
+++ b/bin/k8s-lint
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 . k8s-read-config
 
 LINT_ERROR=0
@@ -13,13 +11,39 @@ files_exist () {
     do
         if [[ -e "${FILE}" ]]
         then
-            echo -e "${CHECKMARK} " "${FILE}" exists
+            echo -e "${CHECKMARK} " "${FILE} exists"
         else
-            echo -e "${SKULL} " ERROR "${FILE}" does not exist
+            echo -e "${SKULL} " "ERROR ${FILE} does not exist"
             LINT_ERROR=1
         fi
     done
 }
+
+check_deployments () {
+    local FILE
+    for FILE in "${@}"
+    do
+        check_deployment "${FILE}"
+    done
+}
+
+check_deployment () {
+    local FILE=$1
+
+    # Check for revisionHistoryLimit
+    grep 'revisionHistoryLimit' "${FILE}" > /dev/null
+    RC=$?
+
+    if [[ $RC -eq 0 ]]
+    then
+        echo -e "${CHECKMARK} " "${FILE} includes revisionHistoryLimit"
+    else
+        echo -e "${SKULL} " "ERROR ${FILE} does not include 'revisionHistoryLimit' https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy"
+        LINT_ERROR=1
+    fi
+}
+
+
 
 main() {
     echo "Linting files"
@@ -36,6 +60,9 @@ main() {
     files_exist "${HORIZONTAL_POD_AUTOSCALER_FILES[@]}"
     files_exist "${POD_DISRUPTION_BUDGET_FILES[@]}"
 
+    check_deployments "${DEPLOYMENT_FILES[@]}"
+
+    echo "Exit: ${LINT_ERROR}"
     exit $LINT_ERROR
 }
 

--- a/bin/k8s-lint
+++ b/bin/k8s-lint
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+. k8s-read-config
+
+LINT_ERROR=0
+CHECKMARK="\xE2\x9C\x93"
+SKULL="\xE2\x98\xA0"
+
+files_exist () {
+    for FILE in "${@}"
+    do
+        if [[ -e "${FILE}" ]]
+        then
+            echo -e "${CHECKMARK} " "${FILE}" exists
+        else
+            echo -e "${SKULL} " ERROR "${FILE}" does not exist
+            LINT_ERROR=1
+        fi
+    done
+}
+
+main() {
+    echo "Linting files"
+    files_exist "${CONFIGMAP_FILES[@]}"
+    files_exist "${PERSISTENT_VOLUME_FILES[@]}"
+    files_exist "${PERSISTENT_VOLUME_CLAIM_FILES[@]}"
+    files_exist "${STATEFULSET_FILES[@]}"
+    files_exist "${SERVICE_FILES[@]}"
+    files_exist "${ENDPOINT_FILES[@]}"
+    files_exist "${INGRESS_FILES[@]}"
+    files_exist "${BLOCKING_JOBS_FILES[@]}"
+    files_exist "${JOBS_FILES[@]}"
+    files_exist "${DEPLOYMENT_FILES[@]}"
+    files_exist "${HORIZONTAL_POD_AUTOSCALER_FILES[@]}"
+    files_exist "${POD_DISRUPTION_BUDGET_FILES[@]}"
+
+    exit $LINT_ERROR
+}
+
+main

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ dependencies:
 
 test:
   override:
-    - shellcheck bin/docker-* bin/ensure-kubectl bin/k8s-apply bin/k8s-secrets-from-s3 bin/verify-deployment
+    - shellcheck bin/docker-* bin/ensure-kubectl bin/k8s-apply bin/k8s-secrets-from-s3 bin/verify-deployment bin/k8s-lint
 
 deployment:
   release:

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ machine:
   environment:
     GITHUB_ORGANIZATION: $CIRCLE_PROJECT_USERNAME
     GITHUB_REPOSITORY: $CIRCLE_PROJECT_REPONAME
+    PATH: ~/$CIRCLE_PROJECT_REPONAME/bin:$PATH
 
 dependencies:
   pre:
@@ -13,6 +14,8 @@ dependencies:
 test:
   override:
     - shellcheck bin/docker-* bin/ensure-kubectl bin/k8s-apply bin/k8s-secrets-from-s3 bin/verify-deployment bin/k8s-lint
+    - cd examples/production-ready; k8s-lint -f staging.config
+    - cd examples/production-ready; k8s-lint -f production.config
 
 deployment:
   release:

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ An example including:
 * Internal ELB for staging
 * Horizontal Pod Autoscaler for setting number of replicas
 * Usage `namespace` metadata to ensure application to the correct Kube namespace
+* Linting of your config and deploy files
 
 Deployment Features:
 * `revisionHistoryLimit` to remove old ReplicaSets

--- a/examples/production-ready/circle.yml
+++ b/examples/production-ready/circle.yml
@@ -20,7 +20,8 @@ dependencies:
 
 test:
   override:
-    - echo "No tests for now!"
+    - k8s-lint -f staging.config
+    - k8s-lint -f production.config
 
 deployment:
   staging:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "k8s-delete": "./bin/k8s-delete",
     "k8s-deploy": "./bin/k8s-deploy",
     "k8s-deploy-and-verify": "./bin/k8s-deploy-and-verify",
+    "k8s-lint": "./bin/k8s-lint",
     "k8s-example-config": "./bin/k8s-example-config",
     "k8s-read-config": "./bin/k8s-read-config",
     "k8s-secrets-from-s3": "./bin/k8s-secrets-from-s3",


### PR DESCRIPTION
Currently checks a few small bits but can be expanded for more thorough cases.

The linter may not follow SemVer as new checks are added.

Example linter output (skipping config read)

```
☠  ERROR /Users/philipcristiano/gits/k8s-scripts/deploy/example-app.statefulset.yml does not exist
✓  /Users/philipcristiano/gits/k8s-scripts/deploy/example-app.service.yml exists
✓  /Users/philipcristiano/gits/k8s-scripts/deploy/example-app.deployment.yml exists
☠  ERROR /Users/philipcristiano/gits/k8s-scripts/deploy/example-app.deployment.yml does not include 'revisionHistoryLimit' https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy
Exit: 1
```