### PR TITLE
Strip Newline Characters from End of Secret Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ data:
   password: example-password
 ```
 
-Most text editors add a newline character to the end of a file which could cause an issue with the secrets on S3 because that newline character will be included in the base64 encoded value in the secrets.yml file. To strip all newline characters from the end of a file pass the `-s` flag to the `k8s-secrets-from-s3` command.
+Most text editors add a newline character to the end of a file which could cause an issue with the secrets on S3 because that newline character will be included in the base64 encoded value in the `deploy/${SECRET}.secret.yaml` file. To strip all newline characters from the end of a file pass the `-s` flag to the `k8s-secrets-from-s3` command.
 
 ### k8s-sops-secret-decrypt
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ data:
   password: example-password
 ```
 
+Most text editors add a newline character to the end of a file which could cause an issue with the secrets on S3 because that newline character will be included in the base64 encoded value in the secrets.yml file. To strip all newline characters from the end of a file pass the `-s` flag to the `k8s-secrets-from-s3` command.
+
 ### k8s-sops-secret-decrypt
 
 Given an [AWS KMS](https://aws.amazon.com/kms/) key id, decrypts a file which is a kubernetes secret YAML. The encrypted secret file is safe to store in git.

--- a/bin/k8s-secrets-from-s3
+++ b/bin/k8s-secrets-from-s3
@@ -7,6 +7,13 @@ if [ -z "$AWS_ACCESS_KEY_ID" ];     then echo AWS_ACCESS_KEY_ID must be set; exi
 if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then echo AWS_SECRET_ACCESS_KEY must be set; exit 1; fi
 if [ -z "$S3_SECRETS" ];            then echo S3_SECRETS must be set; exit 1; fi
 
+while getopts "s" option; do
+    case "$option" in
+        s) STRIP_ENDING_NEWLINE=1 ;;
+    esac
+done
+shift $((OPTIND - 1))
+
 SECRETS_PATH=secrets
 mkdir -p ${SECRETS_PATH}
 
@@ -14,5 +21,6 @@ for index in "${!S3_SECRETS[@]}"
 do
   s3_secret="${S3_SECRETS[$index]}"
   aws s3 cp --recursive "${S3_BUCKET}/${NAMESPACE}/${s3_secret}" "${SECRETS_PATH}/${s3_secret}"
+  if [ ! -z "$STRIP_ENDING_NEWLINE" ]; then printf %s "$(cat ${SECRETS_PATH}/${s3_secret})" > ${SECRETS_PATH}/${s3_secret}; fi;
   kubectl create secret generic "${s3_secret}" --from-file "${SECRETS_PATH}/${s3_secret}" --dry-run -o yaml > "deploy/${s3_secret}".secret.yml
 done

--- a/bin/k8s-secrets-from-s3
+++ b/bin/k8s-secrets-from-s3
@@ -13,15 +13,17 @@ if [ -z "$AWS_ACCESS_KEY_ID" ];     then echo AWS_ACCESS_KEY_ID must be set; exi
 if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then echo AWS_SECRET_ACCESS_KEY must be set; exit 1; fi
 if [ -z "$S3_SECRETS" ];            then echo S3_SECRETS must be set; exit 1; fi
 
-
 SECRETS_PATH=secrets
 mkdir -p ${SECRETS_PATH}
 
 for index in "${!S3_SECRETS[@]}"
 do
   s3_secret="${S3_SECRETS[$index]}"
-  echo "${s3_secret}"
   aws s3 cp --recursive "${S3_BUCKET}/${NAMESPACE}/${s3_secret}" "${SECRETS_PATH}/${s3_secret}"
-  if [ ! -z "$STRIP_ENDING_NEWLINE" ]; then printf %s "$(cat ${SECRETS_PATH}/${s3_secret})" > ${SECRETS_PATH}/${s3_secret}; fi;
+  if [ ! -z "$STRIP_ENDING_NEWLINE" ]; then
+      for f in ${SECRETS_PATH}/${s3_secret}/*; do
+          printf %s "$(cat $f)" > $f;
+      done;
+  fi;
   kubectl create secret generic "${s3_secret}" --from-file "${SECRETS_PATH}/${s3_secret}" --dry-run -o yaml > "deploy/${s3_secret}".secret.yml
 done

--- a/bin/k8s-secrets-from-s3
+++ b/bin/k8s-secrets-from-s3
@@ -1,4 +1,10 @@
 #!/bin/bash -e
+while getopts "s" option; do
+    case "$option" in
+        s) STRIP_ENDING_NEWLINE=1 ;;
+    esac
+done
+shift $((OPTIND - 1))
 
 . k8s-read-config
 
@@ -7,12 +13,6 @@ if [ -z "$AWS_ACCESS_KEY_ID" ];     then echo AWS_ACCESS_KEY_ID must be set; exi
 if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then echo AWS_SECRET_ACCESS_KEY must be set; exit 1; fi
 if [ -z "$S3_SECRETS" ];            then echo S3_SECRETS must be set; exit 1; fi
 
-while getopts "s" option; do
-    case "$option" in
-        s) STRIP_ENDING_NEWLINE=1 ;;
-    esac
-done
-shift $((OPTIND - 1))
 
 SECRETS_PATH=secrets
 mkdir -p ${SECRETS_PATH}
@@ -20,6 +20,7 @@ mkdir -p ${SECRETS_PATH}
 for index in "${!S3_SECRETS[@]}"
 do
   s3_secret="${S3_SECRETS[$index]}"
+  echo "${s3_secret}"
   aws s3 cp --recursive "${S3_BUCKET}/${NAMESPACE}/${s3_secret}" "${SECRETS_PATH}/${s3_secret}"
   if [ ! -z "$STRIP_ENDING_NEWLINE" ]; then printf %s "$(cat ${SECRETS_PATH}/${s3_secret})" > ${SECRETS_PATH}/${s3_secret}; fi;
   kubectl create secret generic "${s3_secret}" --from-file "${SECRETS_PATH}/${s3_secret}" --dry-run -o yaml > "deploy/${s3_secret}".secret.yml


### PR DESCRIPTION
One of the repeated mistakes we have made when using the `k8s-secrets-from-s3` script is that there *should not* be a newline character at the end of the secrets file uploaded to S3. Since most text editors do this by default (and in my opinion rightfully so) newline characters would get inserted into our secrets and our apps would fail because the value for the environment variable incorrectly contained a newline character at the end. To work around this and maintain backwards compatibility I added a new flag to the `k8s-secrets-from-s3` command to strip all newline characters from the end of a secrets file.