### PR TITLE
Remove invalid flag being passed to docker tag

### DIFF
--- a/bin/docker-push
+++ b/bin/docker-push
@@ -31,7 +31,7 @@ then
   exit 1
 fi
 
-docker tag -f "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_REF}"
+docker tag "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_REF}"
 if [ $? -ne 0 ]
 then
   echo "Unable to tag image, aborting"


### PR DESCRIPTION
It does not appear that such a flag (`-f`) exists when looking at the [`docker tag` documentation](https://docs.docker.com/edge/engine/reference/commandline/tag/).