### PR TITLE
add `CronJob` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ JOBS=()
 # List of files ending in '.blockingjob.yml' in the kube directory
 BLOCKING_JOBS=()
 
+# List of files ending in '.cronjob.yml' in the kube directory
+CRONJOBS=()
 
 ```
 

--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -92,6 +92,23 @@ done
 echo "Done deploying Jobs"
 echo ""
 
+echo "Deploying CronJobs"
+for index in "${!CRONJOB_FILES[@]}"
+do
+  CRONJOB=${CRONJOBS[$index]##*/}
+  CRONJOB_FILE=${CRONJOB_FILES[$index]}
+  if [ -n "$CI_SHA1" ]
+  then
+    echo "Updating image tag from latest to ${CI_SHA1} for ${CRONJOB_FILE}"
+    sed 's/:latest/':${CI_SHA1}'/g;' ${CRONJOB_FILE} > ${CRONJOB_FILE}-${CI_SHA1}
+    echo "Updating ${CRONJOB_FILE}-${CI_SHA1}"
+    CRONJOB_FILE=${CRONJOB_FILE}-${CI_SHA1}
+  fi
+  kubectl apply -f ${CRONJOB_FILE} --namespace=$NAMESPACE --record
+done
+echo "Done deploying CronJobs"
+echo ""
+
 echo "Deploying Blocking Jobs"
 for index in "${!BLOCKING_JOBS_FILES[@]}"
 do

--- a/bin/k8s-example-config
+++ b/bin/k8s-example-config
@@ -77,6 +77,8 @@ JOBS=()
 # List of files ending in '.blockingjob.yml' in the kube directory (Not supported yet)
 BLOCKING_JOBS=()
 
+# List of files ending in '.cronjob.yml' in the kube directory
+CRONJOBS=()
 EOT
 
 echo "Wrote example config to $CONFIG"

--- a/bin/k8s-lint
+++ b/bin/k8s-lint
@@ -56,6 +56,7 @@ main() {
     files_exist "${INGRESS_FILES[@]}"
     files_exist "${BLOCKING_JOBS_FILES[@]}"
     files_exist "${JOBS_FILES[@]}"
+    files_exist "${CRONJOB_FILES[@]}"
     files_exist "${DEPLOYMENT_FILES[@]}"
     files_exist "${HORIZONTAL_POD_AUTOSCALER_FILES[@]}"
     files_exist "${POD_DISRUPTION_BUDGET_FILES[@]}"

--- a/bin/k8s-read-config
+++ b/bin/k8s-read-config
@@ -156,3 +156,13 @@ do
 done
 echo "[blocking_jobs_files]: ${BLOCKING_JOBS_FILES[@]}"
 echo ""
+
+
+echo "[cronjobs]: ${CRONJOBS[@]}"
+CRONJOB_FILES=()
+for i in "${CRONJOBS[@]}"
+do
+  CRONJOB_FILES+=($BASEDIR/deploy/$i.cronjob.yml)
+done
+echo "[cronjobs_files]: ${CRONJOB_FILES[@]}"
+echo ""

--- a/examples/production-ready/deploy/minimal-production.cronjob.yml
+++ b/examples/production-ready/deploy/minimal-production.cronjob.yml
@@ -1,0 +1,37 @@
+apiVersion: batch/v2alpha1
+kind: CronJob
+metadata:
+  name: foo
+spec:
+  schedule: "17 * * * *"
+  failedJobsHistoryLimit: 10
+  successfulJobsHistoryLimit: 20
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: foo
+              persistentVolumeClaim:
+                claimName: foo
+          containers:
+          - name: foo
+            image: foo/bar:latest
+            imagePullPolicy: IfNotPresent
+            resources:
+              limits:
+                cpu: 50m
+                memory: 256Mi
+              requests:
+                cpu: 50m
+                memory: 256Mi
+            volumeMounts:
+            - mountPath: /var/foo
+              name: foo
+            args: ["foo-job", "-t", "-c", "foo-arg_1", "foo-arg_2"]
+            env:
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          restartPolicy: OnFailure

--- a/k8s-scripts.config
+++ b/k8s-scripts.config
@@ -41,3 +41,6 @@ JOBS=()
 # List of files ending in '.blockingjob.yml' in the kube directory
 BLOCKING_JOBS=()
 
+# List of files ending in '.cronjob.yml' in the kube directory
+CRONJOBS=()
+


### PR DESCRIPTION
add `CronJob` support

* As of kubernetes 1.5.x, one must enable `batch/v2alpha1` to enable `CronJob` support 
* This PR addresses rok8-scripts ability purely to `kubectl apply -f` filenames who endswith `.cronjob.yml` to the cluster. This does not add any job validation support other than what is provided by `k8s-lint`