### PR TITLE
Fixing cloud-login bug

### DIFF
--- a/bin/cloud-login
+++ b/bin/cloud-login
@@ -6,7 +6,7 @@ then
   return 0
 fi
 
-if [ ! -z "${AWS_ACCESS_KEY_ID}" ]; then
+if [[ (! -z "${AWS_ACCESS_KEY_ID}"  && ! -z "${AWS_ACCESS_KEY_ID}" ) || ( -f ~/.aws/config && -f ~/.aws/credentials ) ]]; then
     prepare-awscli
     CLOUD_LOGGED_IN=true
     return 0


### PR DESCRIPTION
adding further logic so that prepare-awscli gets run when either type of credentials are provided

fixes #87