### PR TITLE
deploy: mawk compatible regex

### DIFF
--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -203,7 +203,7 @@ do
   # this: https://github.com/kubernetes/kubernetes/issues/25238
 
   # If we can match 'replicas: hpa' in te deployment file
-  if [[ -n $( awk -F: '/[rR][eE][pP][lL][iI][cC][aA][sS][[:space:]]*:[[:space:]]*+[hH][pP][aA]/' $DEPLOYMENT_FILE ) ]]
+  if [[ -n $( awk -F: '/[rR][eE][pP][lL][iI][cC][aA][sS] *: +[hH][pP][aA]/' $DEPLOYMENT_FILE ) ]]
   then
     # Get the replica count and sed it into the deployment file in place of 'hpa'
     REPLICA_COUNT=$(kubectl get deployment ${DEPLOYMENT} --namespace=${NAMESPACE} -o json | jq '.status.readyReplicas')


### PR DESCRIPTION
The previous regex fails to match a proper file when run with mawk, which is installed in the circleci/node:7.10 image. Debian includes mawk as the awk implementation it seems. 

This replaces problematic matches with more generic versions.

I expect that this should be backwards compatible, but I'm not too familiar with the various dialects of AWK that various implementations use. 