### PR TITLE
Adding AWS login support for older versions of docker

### DIFF
--- a/bin/docker-resolve
+++ b/bin/docker-resolve
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+if docker login --help | grep email > /dev/null 2>&1; then
+  echo "Using old version of Docker, including email for login"
+  export DOCKER_EMAIL_FLAG='--include-email'
+else
+  export DOCKER_EMAIL_FLAG='--no-include-email'
+fi

--- a/bin/prepare-awscli
+++ b/bin/prepare-awscli
@@ -1,8 +1,17 @@
 #!/bin/bash -e
 
 # shellcheck disable=SC2086
-if [ -z "$AWS_ECR_ACCOUNT_ID" ]; then
-  eval "$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
+
+if docker login --help | grep email > /dev/null 2>&1; then
+  echo "Using old version of Docker, including email for login"
+  EMAIL_FLAG='--include-email'
 else
-  eval "$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --registry-ids ${AWS_ECR_ACCOUNT_ID} --no-include-email)"
+  EMAIL_FLAG='--no-include-email'
+fi
+
+
+if [ -z "$AWS_ECR_ACCOUNT_ID" ]; then
+  eval "$(aws ecr get-login --region ${AWS_DEFAULT_REGION} $EMAIL_FLAG)"
+else
+  eval "$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --registry-ids ${AWS_ECR_ACCOUNT_ID} $EMAIL_FLAG)"
 fi

--- a/bin/prepare-awscli
+++ b/bin/prepare-awscli
@@ -2,16 +2,10 @@
 
 # shellcheck disable=SC2086
 
-if docker login --help | grep email > /dev/null 2>&1; then
-  echo "Using old version of Docker, including email for login"
-  EMAIL_FLAG='--include-email'
-else
-  EMAIL_FLAG='--no-include-email'
-fi
-
+. docker-resolve
 
 if [ -z "$AWS_ECR_ACCOUNT_ID" ]; then
-  eval "$(aws ecr get-login --region ${AWS_DEFAULT_REGION} $EMAIL_FLAG)"
+  eval "$(aws ecr get-login --region ${AWS_DEFAULT_REGION} $DOCKER_EMAIL_FLAG)"
 else
-  eval "$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --registry-ids ${AWS_ECR_ACCOUNT_ID} $EMAIL_FLAG)"
+  eval "$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --registry-ids ${AWS_ECR_ACCOUNT_ID} $DOCKER_EMAIL_FLAG)"
 fi


### PR DESCRIPTION
Docker login is rather brittle across versions, specifically Docker login commands that work with CircleCI 2.0 will break with CircleCI 1.0. This attempts to fix that.