### PR TITLE
Limit use of --cache-from flag to when Docker actually supports it

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 . k8s-read-config "$@"
+. docker-resolve
 
 if [ -z "$BASEDIR" ];    then echo BASEDIR must be set; exit 1; fi
 if [ -z "$DOCKERTAG" ];  then echo DOCKERTAG must be set; exit 1; fi
@@ -9,11 +10,17 @@ if [ -z "$DOCKERFILE" ]; then echo DOCKERFILE must be set; exit 1; fi
 PREVIOUS_COMMIT=$(git rev-parse HEAD~1)
 CI_BRANCH=$(echo "${CI_BRANCH}" | tr / _)
 
-echo "Building ${DOCKERTAG} from ${BASEDIR}/${DOCKERFILE}"
-docker build --rm=false -t "${DOCKERTAG}" -f "${BASEDIR}/${DOCKERFILE}" \
-  --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$PREVIOUS_COMMIT" \
-  --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH" \
-  "${BASEDIR}"
+if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
+  echo "Using --cache-from to improve performance"
+  docker build --rm=false -t "${DOCKERTAG}" -f "${BASEDIR}/${DOCKERFILE}" \
+    --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$PREVIOUS_COMMIT" \
+    --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH" \
+    "${BASEDIR}"
+else
+  echo "--cache-from not available with this version of Docker"
+  docker build --rm=false -t "${DOCKERTAG}" -f "${BASEDIR}/${DOCKERFILE}" "${BASEDIR}"
+fi
+
 if [ $? -ne 0 ]
 then
   echo "Docker build failed! Aborting"

--- a/bin/docker-resolve
+++ b/bin/docker-resolve
@@ -6,3 +6,10 @@ if docker login --help | grep email > /dev/null 2>&1; then
 else
   export DOCKER_EMAIL_FLAG='--no-include-email'
 fi
+
+if docker build --help | grep cache-from> /dev/null 2>&1; then
+  export DOCKER_BUILD_CACHE_FROM='available'
+else
+  echo "Using old version of Docker, --cache-from not supported"
+  export DOCKER_BUILD_CACHE_FROM='unavailable'
+fi


### PR DESCRIPTION
Older version of Docker, including the one found in CircleCI 1.0, don't support `--cache-from`.