### PR TITLE
Fixing deploys with external secrets

### DIFF
--- a/bin/k8s-deploy-secrets
+++ b/bin/k8s-deploy-secrets
@@ -3,12 +3,6 @@
 
 . k8s-read-config
 
-if [ -n "${CONFIG_READ+1}" ]
-then
-  echo "Config already read"
-  return 0
-fi
-
 echo "Deploying Object Store Secrets"
 for EXTERNAL_SECRET_FILE in "${EXTERNAL_SECRET_FILES[@]}"
 do

--- a/bin/k8s-deploy-secrets
+++ b/bin/k8s-deploy-secrets
@@ -3,6 +3,12 @@
 
 . k8s-read-config
 
+if [ -n "${SECRETS_DEPLOYED+1}" ]
+then
+  echo "Secrets already deployed"
+  return 0
+fi
+
 echo "Deploying Object Store Secrets"
 for EXTERNAL_SECRET_FILE in "${EXTERNAL_SECRET_FILES[@]}"
 do

--- a/deploy/example-app-external.secret.external
+++ b/deploy/example-app-external.secret.external
@@ -1,0 +1,1 @@
+s3://rok8s-example-secrets/example-app

--- a/k8s-scripts.config
+++ b/k8s-scripts.config
@@ -15,31 +15,34 @@ REPOSITORY_NAME='example-app'
 DOCKERTAG=quay.io/example-org/example-app
 
 # Namespace to work in
-NAMESPACE='default'
+NAMESPACE='example-app'
 
-# List of files ending in '.configmap.yml' in the kube directory
+# List of files ending in '.configmap.yml' in the deploy directory
 CONFIGMAPS=()
 
-# List of files ending in '.secret.yml' in the kube directory
+# List of files ending in '.secret.yml' in the deploy directory
 SECRETS=('example-app')
 
-# List of files ending in '.statefulset.yml' in the kube directory
+# List of files ending in '.secret.external' in the deploy directory
+EXTERNAL_SECRETS=('example-app-external')
+
+# List of files ending in '.statefulset.yml' in the deploy directory
 STATEFULSETS=()
 
-# List of files ending in '.service.yml' in the kube directory
+# List of files ending in '.service.yml' in the deploy directory
 SERVICES=('example-app')
 
-# List of files ending in '.ingress.yml' in the kube directory
+# List of files ending in '.ingress.yml' in the deploy directory
 INGRESSES=()
 
-# List of files ending in '.deployment.yml' in the kube directory
+# List of files ending in '.deployment.yml' in the deploy directory
 DEPLOYMENTS=('example-app')
 
-# List of files ending in '.job.yml' in the kube directory
+# List of files ending in '.job.yml' in the deploy directory
 JOBS=()
 
-# List of files ending in '.blockingjob.yml' in the kube directory
+# List of files ending in '.blockingjob.yml' in the deploy directory
 BLOCKING_JOBS=(example-app)
 
-# List of files ending in '.cronjob.yml' in the kube directory
+# List of files ending in '.cronjob.yml' in the deploy directory
 CRONJOBS=()


### PR DESCRIPTION
This removes a condition in `k8s-deploy-secrets` that prevented the script from working as part of `k8s-deploy` and adds a better example for external secrets.