### PR TITLE
Updating Docker image used for Circle release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:8.9.4
+      - image: circleci/node:boron-stretch
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
Apparently the version of Git that comes with the previous image I was using is old and doesn't support the `--format` argument on this line (and below): https://github.com/reactiveops/release.sh/blob/master/release#L27. I've tested those commands inside this updated image successfully. 