### PR TITLE
Adding stretch image, removing node7 image, updating kubectl to 1.8.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ references:
       name: Docker build
       command: |
         docker build -f ci-images/node6/Dockerfile -t quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-node6 .
-        docker build -f ci-images/node7/Dockerfile -t quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-node7 .
+        docker build -f ci-images/stretch/Dockerfile -t quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-stretch .
         docker build -f ci-images/alpine/Dockerfile -t quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-alpine .
 
   docker_push: &docker_push
@@ -56,7 +56,7 @@ references:
       name: Docker push
       command: |
         docker push quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-node6
-        docker push quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-node7
+        docker push quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-stretch
         docker push quay.io/reactiveops/ci-images:$DOCKER_BASE_TAG-alpine
 
   npm_release: &npm_release

--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -32,7 +32,7 @@ else
   PKG_INSTALL="${PKG_MANAGER} install -y"
 fi
 
-KUBECTL_VERSION="${KUBECTL_VERSION:-v1.8.7}"
+KUBECTL_VERSION="${KUBECTL_VERSION:-v1.8.10}"
 #make sure sudo is installed
 if ! hash sudo 2>/dev/null; then
   echo Installing sudo...

--- a/ci-images/stretch/Dockerfile
+++ b/ci-images/stretch/Dockerfile
@@ -1,8 +1,9 @@
-FROM circleci/node:7
+FROM circleci/buildpack-deps:stretch
 
 USER root
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     apt-get install -y -qq jq wget python-pip python-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
As luck would have it, `base64` on Alpine expects `-d` as a decode flag, while other distros generally expect `--decode`. Since we happen to rely on that in `prepare-gcloud`, I'm adding a Debian base image (not to say we shouldn't also make `prepare-gcloud` support Alpine in the future). At the same time, it sounds like our `node7` image is not being used, and it's generally a strange version of Node to support since it's not LTS or particularly common in my experience. As a final change here, I took the opportunity to ensure that `install-rok8s-requirements` will install `kubectl` 1.8.10 now.