### PR TITLE
Fix for helm-deploy config

### DIFF
--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -3,8 +3,8 @@
 
 set -eo pipefail
 
- . k8s-read-config
-k8s-deploy-secrets
+. k8s-read-config
+. k8s-deploy-secrets
 
 
 echo "Deploying Helm Charts"


### PR DESCRIPTION
This fixes helm-deploy for instances where a rok8s-scripts config file is specified.