### PR TITLE
only require GCP_ZONE and CLUSTER_NAME if configuring cluster access

### DIFF
--- a/bin/prepare-gcloud
+++ b/bin/prepare-gcloud
@@ -1,12 +1,10 @@
 #!/bin/bash -e
 echo "Preparing the gcloud command line tools."
 
-if [[ -z ${GCP_PROJECT+x} ]] || [[ -z ${GCP_ZONE+x} ]] || [[ -z ${GCLOUD_KEY+x} ]] || [[ -z ${CLUSTER_NAME+x} ]]; then
+if [[ -z ${GCP_PROJECT+x} ]] || [[ -z ${GCLOUD_KEY+x} ]] ; then
   echo -n "Missing required variable(s):"
   [[ -n ${GCP_PROJECT+x} ]] || echo -n " GCP_PROJECT"
-  [[ -n ${GCP_ZONE+x} ]] || echo -n " GCP_ZONE"
   [[ -n ${GCLOUD_KEY+x} ]] || echo -n " GCLOUD_KEY"
-  [[ -n ${CLUSTER_NAME+x} ]] || echo -n " CLUSTER_NAME"
   echo ""
   exit 1
 fi
@@ -27,5 +25,10 @@ gcloud config set project "${GCP_PROJECT}"
 # Authorize the docker client to work with GCR
 gcloud docker --authorize-only
 
-# Setup cluster credentials
-gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${GCP_ZONE}" --project "${GCP_PROJECT}"
+if [[ ${GCP_ZONE+x} ]] || [[ ${CLUSTER_NAME+x} ]] ; then
+  echo "Configuring cluster credentials."
+  # Setup cluster credentials
+  gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${GCP_ZONE}" --project "${GCP_PROJECT}"
+  echo ""
+  exit 0
+fi


### PR DESCRIPTION
we should only require these variables if configuring cluster access; this gives us the capability to use the prepare-gcloud functionality in CI/CD workflow scenarios where we want to push images to GCR without necessarily interacting with a GKE cluster. 