### PR TITLE
Some tweaks for prepare-gcloud

### DIFF
--- a/bin/prepare-gcloud
+++ b/bin/prepare-gcloud
@@ -1,4 +1,7 @@
 #!/bin/bash -e
+
+# shellcheck disable=SC2016
+
 echo "Preparing the gcloud command line tools."
 echo 'Ensure that the following environment variable is also set'
 echo 'export GOOGLE_APPLICATION_CREDENTIALS="${ROK8S_TMP}/gcloud-service-key.json"'

--- a/bin/prepare-gcloud
+++ b/bin/prepare-gcloud
@@ -2,10 +2,11 @@
 
 echo "Preparing the gcloud command line tools."
 
-if [[ -z ${GCP_PROJECT+x} ]] || [[ -z ${GCLOUD_KEY+x} ]] ; then
+if [[ -z ${GCP_PROJECT+x} ]] || [[ -z ${GCLOUD_KEY+x} ]] || [[ -z ${GOOGLE_APPLICATION_CREDENTIALS+x} ]] ; then
   echo -n "Missing required variable(s):"
   [[ -n ${GCP_PROJECT+x} ]] || echo -n " GCP_PROJECT"
   [[ -n ${GCLOUD_KEY+x} ]] || echo -n " GCLOUD_KEY"
+  [[ -n ${GOOGLE_APPLICATION_CREDENTIALS+x} ]] || echo -n " GOOGLE_APPLICATION_CREDENTIALS"
   echo ""
   exit 1
 fi
@@ -17,8 +18,6 @@ fi
 ROK8S_TMP="${ROK8S_TMP:-${HOME}}"
 mkdir -p "${ROK8S_TMP}"
 
-# This does not set this variable outside of this script
-export GOOGLE_APPLICATION_CREDENTIALS="${ROK8S_TMP}/gcloud-service-key.json"
 echo "${GCLOUD_KEY}" | base64 --decode > "$GOOGLE_APPLICATION_CREDENTIALS"
 gcloud auth activate-service-account --configuration "rok8s-${GCP_PROJECT}" --key-file "$GOOGLE_APPLICATION_CREDENTIALS" --project "${GCP_PROJECT}"
 
@@ -36,7 +35,3 @@ else
   gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${GCP_ZONE}" --project "${GCP_PROJECT}"
   echo ""
 fi
-
-echo ""
-echo "Ensure that the following environment variable is also set:"
-echo export GOOGLE_APPLICATION_CREDENTIALS="${ROK8S_TMP}/gcloud-service-key.json"

--- a/bin/prepare-gcloud
+++ b/bin/prepare-gcloud
@@ -1,11 +1,6 @@
 #!/bin/bash -e
 
-# shellcheck disable=SC2016
-
 echo "Preparing the gcloud command line tools."
-echo 'Ensure that the following environment variable is also set'
-echo 'export GOOGLE_APPLICATION_CREDENTIALS="${ROK8S_TMP}/gcloud-service-key.json"'
-
 
 if [[ -z ${GCP_PROJECT+x} ]] || [[ -z ${GCLOUD_KEY+x} ]] ; then
   echo -n "Missing required variable(s):"
@@ -21,6 +16,7 @@ fi
 
 ROK8S_TMP="${ROK8S_TMP:-${HOME}}"
 mkdir -p "${ROK8S_TMP}"
+
 # This does not set this variable outside of this script
 export GOOGLE_APPLICATION_CREDENTIALS="${ROK8S_TMP}/gcloud-service-key.json"
 echo "${GCLOUD_KEY}" | base64 --decode > "$GOOGLE_APPLICATION_CREDENTIALS"
@@ -39,5 +35,8 @@ else
   # Setup cluster credentials
   gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${GCP_ZONE}" --project "${GCP_PROJECT}"
   echo ""
-  exit 0
 fi
+
+echo ""
+echo "Ensure that the following environment variable is also set:"
+echo export GOOGLE_APPLICATION_CREDENTIALS="${ROK8S_TMP}/gcloud-service-key.json"

--- a/bin/prepare-gcloud
+++ b/bin/prepare-gcloud
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 echo "Preparing the gcloud command line tools."
+echo 'Ensure that the following environment variable is also set'
+echo 'export GOOGLE_APPLICATION_CREDENTIALS="${ROK8S_TMP}/gcloud-service-key.json"'
+
 
 if [[ -z ${GCP_PROJECT+x} ]] || [[ -z ${GCLOUD_KEY+x} ]] ; then
   echo -n "Missing required variable(s):"
@@ -15,6 +18,7 @@ fi
 
 ROK8S_TMP="${ROK8S_TMP:-${HOME}}"
 mkdir -p "${ROK8S_TMP}"
+# This does not set this variable outside of this script
 export GOOGLE_APPLICATION_CREDENTIALS="${ROK8S_TMP}/gcloud-service-key.json"
 echo "${GCLOUD_KEY}" | base64 --decode > "$GOOGLE_APPLICATION_CREDENTIALS"
 gcloud auth activate-service-account --configuration "rok8s-${GCP_PROJECT}" --key-file "$GOOGLE_APPLICATION_CREDENTIALS" --project "${GCP_PROJECT}"
@@ -25,7 +29,9 @@ gcloud config set project "${GCP_PROJECT}"
 # Authorize the docker client to work with GCR
 gcloud docker --authorize-only
 
-if [[ ${GCP_ZONE+x} ]] || [[ ${CLUSTER_NAME+x} ]] ; then
+if [[ -z ${GCP_ZONE+x} ]] || [[ -z ${CLUSTER_NAME+x} ]] ; then
+  echo "Missing required variables to get cluster credentials (GCP_ZONE and CLUSTER_NAME)"
+else
   echo "Configuring cluster credentials."
   # Setup cluster credentials
   gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${GCP_ZONE}" --project "${GCP_PROJECT}"


### PR DESCRIPTION
This PR has two goals:
1. Provide a better explanation for what to do with `GOOGLE_APPLICATION_CREDENTIALS`
2. Ensure that both `GCP_ZONE` and `CLUSTER_NAME` are set before trying to fetch cluster credentials.