### PR TITLE
move npm_release after github release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,11 +117,11 @@ jobs:
       - run: echo 'export GITHUB_ORGANIZATION=$CIRCLE_PROJECT_USERNAME' >> $BASH_ENV
       - run: echo 'export GITHUB_REPOSITORY=$CIRCLE_PROJECT_REPONAME' >> $BASH_ENV
       - run: echo 'export DOCKER_BASE_TAG=$CIRCLE_TAG' >> $BASH_ENV
-      - *npm_release
       - *github_release
       - *docker_login
       - *docker_build
       - *docker_push
+      - *npm_release
 
 
 workflows:


### PR DESCRIPTION
Move npm release to occur after the github release and docker release because if there is an error in one of the steps that come after the npm release, we are unable to delete that release.