### PR TITLE
Create configmaps from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ NAMESPACE='default'
 # List of files ending in '.configmap.yml' in the kube directory
 CONFIGMAPS=()
 
+# List of files ending in '.configmap.fromfile' in the kube directory
+FROMFILE_CONFIGMAPS=()
+
 # List of files ending in '.secret.yml' in the kube directory
 SECRETS=('example-app')
 

--- a/bin/k8s-delete
+++ b/bin/k8s-delete
@@ -10,6 +10,14 @@ do
 done
 echo "Done deleting ConfigMaps"
 
+echo "Deleting ConfigMaps"
+for index in "${!FROMFILE_CONFIGMAP_FILES[@]}"
+do
+  FROMFILE_CONFIGMAP_FILE=${FROMFILE_CONFIGMAP_FILES[$index]}
+  kubectl delete -f $FROMFILE_CONFIGMAP_FILE --namespace=$NAMESPACE || true
+done
+echo "Done deleting From File ConfigMaps"
+
 echo "Deleting Secrets"
 for index in "${!SECRET_FILES[@]}"
 do

--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -23,10 +23,10 @@ echo "Deploying From File Configmaps"
 for index in "${!FROMFILE_CONFIGMAP_FILES[@]}"; do
   CONFIGMAP_FILE=${FROMFILE_CONFIGMAP_FILES[$index]}
 
-  CONFIGMAP_NAME=${EXTERNAL_SECRET_FILE##*/}
+  CONFIGMAP_NAME=${CONFIGMAP_FILE##*/}
   CONFIGMAP_NAME=${CONFIGMAP_NAME%.configmap.fromfile}
 
-  FROMFILES="$(cat ${CONFIGMAP_FILE}[$index])"
+  FROMFILES="$(cat ${CONFIGMAP_FILE})"
   FROMFILE_ARGS=""
   for FROMFILE in $FROMFILES
   do

--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -19,6 +19,26 @@ done
 echo "Done deploying ConfigMaps"
 echo ""
 
+echo "Deploying From File Configmaps"
+for index in "${!FROMFILE_CONFIGMAP_FILES[@]}"; do
+  CONFIGMAP_FILE=${FROMFILE_CONFIGMAP_FILES[$index]}
+
+  CONFIGMAP_NAME=${EXTERNAL_SECRET_FILE##*/}
+  CONFIGMAP_NAME=${CONFIGMAP_NAME%.configmap.fromfile}
+
+  FROMFILES="$(cat ${CONFIGMAP_FILE}[$index])"
+  FROMFILE_ARGS=""
+  for FROMFILE in $FROMFILES
+  do
+    FROMFILE_ARGS+=" --from-file=$FROMFILE "
+  done
+
+  echo "Applying ${FROMFILE_CONFIGMAP_FILES}"
+  kubectl create ${CONFIGMAP_NAME} --namespace=$NAMESPACE --record ${FROMFILE_ARGS} --dry-run -o yaml | kubectl apply --namespace=$NAMESPACE -f -
+done
+echo "Done deploying From File ConfigMaps"
+echo ""
+
 echo "Deploying Services"
 for index in "${!SERVICE_FILES[@]}"
 do

--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -34,7 +34,7 @@ for index in "${!FROMFILE_CONFIGMAP_FILES[@]}"; do
   done
 
   echo "Applying ${FROMFILE_CONFIGMAP_FILES}"
-  kubectl create configmap ${CONFIGMAP_NAME} --namespace=$NAMESPACE --record ${FROMFILE_ARGS} --dry-run -o yaml | kubectl apply --namespace=$NAMESPACE -f -
+  kubectl create configmap ${CONFIGMAP_NAME} --namespace=$NAMESPACE ${FROMFILE_ARGS} --dry-run -o yaml | kubectl apply --namespace=$NAMESPACE -f -
 done
 echo "Done deploying From File ConfigMaps"
 echo ""

--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -34,7 +34,7 @@ for index in "${!FROMFILE_CONFIGMAP_FILES[@]}"; do
   done
 
   echo "Applying ${FROMFILE_CONFIGMAP_FILES}"
-  kubectl create ${CONFIGMAP_NAME} --namespace=$NAMESPACE --record ${FROMFILE_ARGS} --dry-run -o yaml | kubectl apply --namespace=$NAMESPACE -f -
+  kubectl create configmap ${CONFIGMAP_NAME} --namespace=$NAMESPACE --record ${FROMFILE_ARGS} --dry-run -o yaml | kubectl apply --namespace=$NAMESPACE -f -
 done
 echo "Done deploying From File ConfigMaps"
 echo ""

--- a/bin/k8s-read-config
+++ b/bin/k8s-read-config
@@ -75,6 +75,9 @@ function expand_files() {
 CONFIGMAP_FILES=()
 expand_files "CONFIGMAPS" "CONFIGMAP_FILES" "configmap.yml"
 
+FROMFILE_CONFIGMAP_FILES=()
+expand_files "FROMFILE_CONFIGMAPS" "FROMFILE_CONFIGMAP_FILES" "configmap.fromfile"
+
 SECRET_FILES=()
 expand_files "SECRETS" "SECRET_FILES" "secret.yml"
 


### PR DESCRIPTION
There is currently no way to use a reference file when creating a configmap from a YML file. Adding this functionality to get around that. This will take a `configName.configmap.fromfile` file and then create a configmap out of the files it references, one per line.