### PR TITLE
Adding docker-credential-gcloud

### DIFF
--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -83,6 +83,7 @@ if ! hash gcloud 2>/dev/null; then
     curl https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_cloud_sdk.bash | \
       bash -s -- --disable-prompts
   ln -s "${HOME}/google-cloud-sdk/bin/gcloud" "${ROK8S_INSTALL_PATH}/gcloud"
+  ln -s "${HOME}/google-cloud-sdk/bin/docker-credential-gcloud" "${ROK8S_INSTALL_PATH}/docker-credential-gcloud"
   ln -s "${HOME}/google-cloud-sdk/bin/gsutil" "${ROK8S_INSTALL_PATH}/gsutil"
 fi
 


### PR DESCRIPTION
This is required in `PATH` for the new Docker login process to work for gcloud.