### PR TITLE
Adding namespace before secrets in helm-deploy

### DIFF
--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -3,6 +3,14 @@
 set -eo pipefail
 
 . k8s-read-config
+
+# shellcheck disable=SC2086
+if [[ ! $(kubectl get namespace $NAMESPACE) ]]; then
+  echo "Creating ${NAMESPACE} namespace"
+  # shellcheck disable=SC2086
+  kubectl create namespace $NAMESPACE;
+fi
+
 . k8s-deploy-secrets
 
 HELM_DEFAULT_TIMEOUT=300
@@ -16,13 +24,6 @@ format_multiple_values_files() {
   done
   echo "${formatted_files%?}" )
 }
-
-# shellcheck disable=SC2086
-if [[ ! $(kubectl get namespace $NAMESPACE) ]]; then
-  echo "Creating ${NAMESPACE} namespace"
-  # shellcheck disable=SC2086
-  kubectl create namespace $NAMESPACE;
-fi
 
 echo "Deploying Helm Charts"
 for index in "${!HELM_CHARTS[@]}"


### PR DESCRIPTION
Previously if a namespace did not exist, `helm-deploy` would fail if Sops secrets were involved.