### PR TITLE
Handling caching for multi-stage docker builds

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -12,11 +12,38 @@ CI_BRANCH=$(echo "${CI_BRANCH}" | tr / _)
 
 if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
   echo "Using --cache-from to improve performance"
+
+  CACHE_FROM_TARGETS=""
+  # shellcheck disable=2086
+  while read -r CACHE_TARGET; do
+    echo "Working on Dockerfile target[${CACHE_TARGET}]..."
+    TARGET_TAG=cache-${CI_BRANCH}-${CACHE_TARGET}
+    TARGET_IMAGE=${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}
+
+    echo "Checking for existing cache image for target[${CACHE_TARGET}]..."
+    docker pull "${TARGET_IMAGE}:${TARGET_TAG}" || true
+    docker pull "${TARGET_IMAGE}:master" || true
+
+    echo "Building Dockerfile target[${CACHE_TARGET}]..."
+    # shellcheck disable=2086
+    docker build --rm=false -t "${TARGET_IMAGE}:${TARGET_TAG}" -f "${BASEDIR}/${DOCKERFILE}" \
+      --target "${CACHE_TARGET}" \
+      ${CACHE_FROM_TARGETS} \
+      --cache-from "${TARGET_IMAGE}:${TARGET_TAG}" \
+      --cache-from "${TARGET_IMAGE}:master" \
+      "${BASEDIR}"
+    CACHE_FROM_TARGETS="${CACHE_FROM_TARGETS} --cache-from ${TARGET_IMAGE}:${TARGET_TAG}"
+  done <<< "$(grep -i '^FROM.* AS ' ${DOCKERFILE} | awk '{print $4}')"
+
   docker pull "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$PREVIOUS_COMMIT" || true
   docker pull "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH" || true
+  docker pull "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:master" || true
+  # shellcheck disable=2086
   docker build --rm=false -t "${DOCKERTAG}" -f "${BASEDIR}/${DOCKERFILE}" \
+    ${CACHE_FROM_TARGETS} \
     --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$PREVIOUS_COMMIT" \
     --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:$CI_BRANCH" \
+    --cache-from "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:master" \
     "${BASEDIR}"
 else
   echo "--cache-from not available with this version of Docker"

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 . k8s-read-config "$@"
+. docker-resolve
 
 if [ -z "$EXTERNAL_REGISTRY_BASE_DOMAIN" ]; then echo EXTERNAL_REGISTRY_BASE_DOMAIN must be set; exit 1; fi
 if [ -z "$REPOSITORY_NAME" ];               then echo REPOSITORY_NAME must be set; exit 1; fi
@@ -16,52 +17,32 @@ if [ -z "$CI_REF" ]; then echo CI_BRANCH or CI_TAG must be set; exit 1; fi
 
 CI_REF=$(echo "${CI_REF}" | tr / _)
 
+tag_push() {
+  if ! docker tag "$1" "$2"
+  then
+    echo "Unable to tag image, aborting"
+    exit 1
+  fi
+
+  if ! docker push "$2"
+  then
+    echo "Unable to push docker image, aborting."
+    exit 1
+  fi
+}
+
+if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
+  # shellcheck disable=2086
+  while read -r CACHE_TARGET; do
+    TARGET_TAG=cache-${CI_REF}-${CACHE_TARGET}
+    TARGET_IMAGE=${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}
+    echo "Pushing ${TARGET_IMAGE}:${TARGET_TAG}..."
+    docker push "${TARGET_IMAGE}:${TARGET_TAG}"
+  done <<< "$(grep -i '^FROM.* AS ' ${DOCKERFILE} | awk '{print $4}')"
+fi
+
 echo "Pushing ${DOCKERTAG}:latest as ${CI_SHA1}, ${CI_REF}, ${CI_BUILD_NUM} to ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}"
 
-if ! docker tag "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_SHA1}"
-then
-  echo "Unable to tag image, aborting"
-  exit 1
-fi
-
-if ! docker push "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_SHA1}"
-then
-  echo "Unable to push docker image, aborting."
-  exit 1
-fi
-
-DOCKER_TAG_COM="docker tag"
-version=$(docker version | grep -e Version | head -n 1 | awk '{ print $2 }')
-major=$(echo "${version}" | awk -F. '{ print $1 }')
-minor=$(echo "${version}" | awk -F. '{ print $2 }')
-
-if [[ "${minor#0}" -le 9 && "${major}" -eq 1 ]] || [ "${major}" -eq 0 ]
-then
-  DOCKER_TAG_COM="${DOCKER_TAG_COM} -f "
-fi
-
-
-if ! $DOCKER_TAG_COM "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_REF}"
-then
-  echo "Unable to tag image, aborting"
-  exit 1
-fi
-
-if ! docker push "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_REF}"
-then
-  echo "Unable to push docker image, aborting."
-  exit 1
-fi
-
-
-if ! $DOCKER_TAG_COM "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:build_${CI_BUILD_NUM}"
-then
-  echo "Unable to tag image, aborting"
-  exit 1
-fi
-
-if ! docker push "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:build_${CI_BUILD_NUM}"
-then
-  echo "Unable to push docker image, aborting."
-  exit 1
-fi
+tag_push "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_SHA1}"
+tag_push "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_REF}"
+tag_push "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:build_${CI_BUILD_NUM}"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.2.6'
+__version__ = '7.9.0'
 __author__ = 'ReactiveOps, Inc.'
 
 


### PR DESCRIPTION
For multi-stage docker builds this:

* builds and tags each stage separately (with the tag `cache-<branchname>-<stagename>`)
* pushes all the stages in addition to the main image
* pulls the cached stages before each build 

I also DRY'd the tag and push process in `docker-pull`