### PR TITLE
Add options to aid transitioning resources into helm

### DIFF
--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -11,9 +11,16 @@ if [[ ! $(kubectl get namespace $NAMESPACE) ]]; then
   kubectl create namespace $NAMESPACE;
 fi
 
-. k8s-deploy-secrets
+# If using k8s-deploy in combination with helm-deploy
+#  while transitioning to helm, set this to avoid deploying
+#  secrets twice
+if [[ -z "${ROK8S_HELM_TRANSITIONING}" ]]; then
+  . k8s-deploy-secrets
+fi
 
 HELM_DEFAULT_TIMEOUT=300
+HELM_HOME=${HELM_HOME}
+helm init --client-only
 
 format_multiple_values_files() {
   values_files="$1"
@@ -23,6 +30,16 @@ format_multiple_values_files() {
     formatted_files="${formatted_files}${file}"
   done
   echo "${formatted_files%?}" )
+}
+
+helm_upgrade() {
+  helm upgrade --install "${CHART_RELEASE_NAME}" \
+    "./deploy/${CHART_PATH}" -f "${CHART_VALUES}" \
+    --set image.tag="${CI_SHA1}" \
+    --namespace="${NAMESPACE}" \
+    --wait \
+    --timeout "${HELM_TIMEOUTS[$index]:-$HELM_DEFAULT_TIMEOUT}" \
+      2>&1 | tee "${ROK8S_TMP}/helm.out"
 }
 
 echo "Deploying Helm Charts"
@@ -42,8 +59,25 @@ do
   fi
 
   echo "Applying ${CHART_PATH} with ${CHART_VALUES}"
-  helm upgrade --install "${CHART_RELEASE_NAME}" "./deploy/${CHART_PATH}" -f "${CHART_VALUES}" --set image.tag="${CI_SHA1}" --namespace="${NAMESPACE}" --wait --timeout "${HELM_TIMEOUTS[$index]:-$HELM_DEFAULT_TIMEOUT}"
-
+  helm dep up "./deploy/${CHART_PATH}"
+  set +e
+  helm_upgrade
+  helm_ret=$?
+  set -e
+  if [ $helm_ret -gt 0 ] && grep -q "already exists" "${ROK8S_TMP}/helm.out"; then
+    echo "Detected that there are existing resources."
+    if [ -n "${ROK8S_HELM_ADOPT_EXISTING}" ]; then
+      echo "Attempting to force adoption of existing resources."
+      latest_revision=$(helm get "${CHART_RELEASE_NAME}" | grep REVISION | awk '{print $2}')
+      kubectl -n kube-system label cm "${CHART_RELEASE_NAME}.v${latest_revision}" STATUS=DEPLOYED --overwrite
+      helm_upgrade
+    else
+      echo "Not attempting adoption. Set ROK8ROK8S_HELM_ADOPT_EXISTING=1 to try adopting existing resources."
+      exit $helm_ret
+    fi
+  elif [ $helm_ret -gt 0 ]; then
+    exit $helm_ret
+  fi
 done
 echo "Done deploying Helm Charts"
 echo ""


### PR DESCRIPTION
The goal here is to ease the transition of apps into helm. Helm initially fails to deploy a release that would overwrite an existing resource. You can get helm to adopt those resources by forcing a deployment to `SUCCESS` after it initially fails and then redeploying.

This is all behind feature flags. The `ROK8ROK8S_HELM_ADOPT_EXISTING` flag controls most of it, but there is also `ROK8S_HELM_TRANSITIONING` which disables calling `k8s-deploy-secrets` in the case where not everything has moved into helm and `k8s-deploy` is still being used.