### PR TITLE
Adds ssh client to alpine image

### DIFF
--- a/ci-images/alpine/Dockerfile
+++ b/ci-images/alpine/Dockerfile
@@ -2,7 +2,7 @@ FROM docker:18
 
 USER root
 
-RUN apk add --update --no-cache jq wget py-pip curl bash git
+RUN apk add --update --no-cache jq wget py-pip curl bash git openssh-client
 
 COPY bin /usr/local/bin
 RUN install-rok8s-requirements


### PR DESCRIPTION
Needed for more advanced git cloning. it also gets rid of this error in circle builds: 
![image](https://user-images.githubusercontent.com/9451328/42591509-bab8c9e4-84fb-11e8-95b4-93968d69eb53.png)
