### PR TITLE
Remove unused environment variable

### DIFF
--- a/bin/helm-template
+++ b/bin/helm-template
@@ -18,7 +18,6 @@ for index in "${!HELM_CHARTS[@]}"
 do
 
   CHART_PATH=${HELM_CHARTS[$index]}
-  CHART_RELEASE_NAME=${HELM_RELEASE_NAMES[$index]:-${HELM_CHARTS[$index]}}
   CHART_VALUES=${HELM_VALUES[$index]}
 
   # if there is more than one values files listed


### PR DESCRIPTION
An extraneous env var is causing CI to fail on `shellcheck`.