### PR TITLE
Bump setup.py version and add version check to build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ references:
         touch /tmp/libc.so.6
         export LD_LIBRARY_PATH=/tmp # hack to work around a bug with a statically linked lib https://github.com/koalaman/shellcheck/issues/1053
         shellcheck --version
-        pip install semver
 
   npm_install: &npm_install
     run:
@@ -51,6 +50,7 @@ references:
     run:
       name: Check setup.py version number against git release tag
       command: |
+        pip install semver
         latest_release="$(git describe --abbrev=0 --tags)"
         latest_release="${latest_release#*v}"
         setup_py_version="$(python setup.py --version)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ references:
         touch /tmp/libc.so.6
         export LD_LIBRARY_PATH=/tmp # hack to work around a bug with a statically linked lib https://github.com/koalaman/shellcheck/issues/1053
         shellcheck --version
+        pip install semver
 
   npm_install: &npm_install
     run:
@@ -45,6 +46,19 @@ references:
         cd examples/production-ready
         k8s-lint -f staging.config
         k8s-lint -f production.config
+
+  check_setup_py_version: &check_setup_py_version
+    run:
+      name: Check setup.py version number against git release tag
+      command: |
+        latest_release="$(git describe --abbrev=0 --tags)"
+        latest_release="${latest_release#*v}"
+        setup_py_version="$(python setup.py --version)"
+
+        if ! python -c "import semver, sys; sys.exit(0 if semver.match('${setup_py_version}', '>=${latest_release}') else 1)"; then
+          echo "Repo setup.py version is stale: $setup_py_version Latest Git tag release: $latest_release"
+          exit 1
+        fi
 
   docker_login: &docker_login
     run:
@@ -85,7 +99,6 @@ references:
         curl -O https://raw.githubusercontent.com/reactiveops/release.sh/v0.0.2/release
         /bin/bash release
 
-
 jobs:
   test_npm:
     docker:
@@ -105,6 +118,7 @@ jobs:
       - *install_test_dependencies
       - *pip_install
       - *run_shellcheck
+      - *check_setup_py_version
       - *run_basic_linting
 
   build:

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ __author__ = 'ReactiveOps, Inc.'
 
 
 bin_files = glob.glob('./bin/*')
-print(bin_files)
 
 setup(name='rok8s-scripts',
       version=__version__,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.9.1'
+__version__ = '7.11.1'
 __author__ = 'ReactiveOps, Inc.'
 
 


### PR DESCRIPTION
Bump the setup.py version number to match the latest tag. 

Since we pip install from git version mismatches get confusing. So I also added a CI check to fail when the setup.py version is less than the latest tag. CI will complain when we fall behind. I thought about adding the check to the release job but by the time the branch is tagged it's too late to correct without re-tagging.