### PR TITLE
remote kubeconfig: use yml suffix vs. kms. 

### DIFF
--- a/bin/decrypt-kubecfg
+++ b/bin/decrypt-kubecfg
@@ -28,7 +28,7 @@ function decrypt () {
   local CL=${K8S_SHORTNAME}
   local SERVICE_ACCOUNT_NAME=${1}
 
-  sops -d /tmp/${CL}-${SERVICE_ACCOUNT_NAME}-kubeconfig.kms \
+  sops -d /tmp/${CL}-${SERVICE_ACCOUNT_NAME}-kubeconfig.yml \
     | base64 \
     > /tmp/kubeconfig
 }

--- a/bin/get-remote-kubecfg
+++ b/bin/get-remote-kubecfg
@@ -25,7 +25,7 @@ function get_secret () {
   local SERVICE_ACCOUNT_NAME=${3}
   local CL=${K8S_SHORTNAME}
 
-  aws s3 cp ${BUCKET_ADDRESS}/${BUCKET_KEY}/${CL}/${CL}-${SERVICE_ACCOUNT_NAME}-kubeconfig.kms \
+  aws s3 cp ${BUCKET_ADDRESS}/${BUCKET_KEY}/${CL}/${CL}-${SERVICE_ACCOUNT_NAME}-kubeconfig.yml \
   /tmp/
 
 }

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.11.1'
+__version__ = '7.12.0'
 __author__ = 'ReactiveOps, Inc.'
 
 


### PR DESCRIPTION
sops is being inconsistent about decrypting this suffix