### PR TITLE
Add support for deploying to a regional GKE cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,16 @@ Container Registry and sets the default GCP projecct. This requires:
 * `GCP_PROJECT` - The GCP project name (as passed to `gcloud` with `--project`)
 * `GCLOUD_KEY` - The base64-encoded service account credentials
 
+Additional Variables are also needed depending on the type of GKE cluster:
+
+#### Single Zone Clusters (default)
+* `GCP_ZONE` - The zone of the cluster
+
+#### Regional Clusters
+* `GCP_REGIONAL_CLUSTER` - Set to `yes` to indicate the cluster is regional
+* `GCP_REGION` - The region of the cluster
+
+
 ### prepare-kubectl
 Initializes the Kubernetes config to be used with kubectl using a base64-encoded
 config file from the `KUBECONFIG_DATA` variable. If `KUBECONFIG_DATA` is defined

--- a/bin/prepare-gcloud
+++ b/bin/prepare-gcloud
@@ -32,11 +32,23 @@ gcloud config set project "${GCP_PROJECT}"
 # Authorize the docker client to work with GCR
 gcloud auth configure-docker --quiet
 
-if [[ -z ${GCP_ZONE+x} ]] || [[ -z ${CLUSTER_NAME+x} ]] ; then
-  echo "Missing required variables to get cluster credentials (GCP_ZONE and CLUSTER_NAME)"
+
+if [[ -z "${GCP_REGIONAL_CLUSTER+x}" ]]; then
+  if [[ -z ${GCP_REGION+x} ]] || [[ -z ${CLUSTER_NAME+x} ]] ; then
+    echo "Missing required variables to get cluster credentials (GCP_REGION and CLUSTER_NAME)"
+  else
+    echo "Configuring cluster credentials."
+    # Setup cluster credentials
+    gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${GCP_REGION}" --project "${GCP_PROJECT}"
+    echo ""
+  fi
 else
-  echo "Configuring cluster credentials."
-  # Setup cluster credentials
-  gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${GCP_ZONE}" --project "${GCP_PROJECT}"
-  echo ""
+  if [[ -z ${GCP_ZONE+x} ]] || [[ -z ${CLUSTER_NAME+x} ]] ; then
+    echo "Missing required variables to get cluster credentials (GCP_ZONE and CLUSTER_NAME)"
+  else
+    echo "Configuring cluster credentials."
+    # Setup cluster credentials
+    gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${GCP_ZONE}" --project "${GCP_PROJECT}"
+    echo ""
+  fi
 fi

--- a/bin/prepare-gcloud
+++ b/bin/prepare-gcloud
@@ -34,21 +34,21 @@ gcloud auth configure-docker --quiet
 
 
 if [[ -z "${GCP_REGIONAL_CLUSTER+x}" ]]; then
-  if [[ -z ${GCP_REGION+x} ]] || [[ -z ${CLUSTER_NAME+x} ]] ; then
-    echo "Missing required variables to get cluster credentials (GCP_REGION and CLUSTER_NAME)"
-  else
-    echo "Configuring cluster credentials."
-    # Setup cluster credentials
-    gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${GCP_REGION}" --project "${GCP_PROJECT}"
-    echo ""
-  fi
-else
   if [[ -z ${GCP_ZONE+x} ]] || [[ -z ${CLUSTER_NAME+x} ]] ; then
     echo "Missing required variables to get cluster credentials (GCP_ZONE and CLUSTER_NAME)"
   else
     echo "Configuring cluster credentials."
     # Setup cluster credentials
     gcloud container clusters get-credentials "${CLUSTER_NAME}" --zone "${GCP_ZONE}" --project "${GCP_PROJECT}"
+    echo ""
+  fi
+else
+  if [[ -z ${GCP_REGION+x} ]] || [[ -z ${CLUSTER_NAME+x} ]] ; then
+    echo "Missing required variables to get cluster credentials (GCP_REGION and CLUSTER_NAME)"
+  else
+    echo "Configuring cluster credentials."
+    # Setup cluster credentials
+    gcloud container clusters get-credentials "${CLUSTER_NAME}" --region "${GCP_REGION}" --project "${GCP_PROJECT}"
     echo ""
   fi
 fi


### PR DESCRIPTION
Regional GKE clusters require the `--region` flag instead of the `--zone` flag when getting credentials. 

Added a flag `GCP_REGIONAL_CLUSTER` to specify if the cluster to connect to is regional and added the `GCP_REGION` environment variable for specifying the region of the cluster.