### PR TITLE
removing sops key check - as the name of key a secret is encrypted wi…

### DIFF
--- a/bin/k8s-read-config
+++ b/bin/k8s-read-config
@@ -137,14 +137,3 @@ CLUSTER_NAME=${CLUSTER_NAME}
 echo "[cluster_name]: $CLUSTER_NAME"
 echo ""
 
-# Validate we have a sops key if need it
-if [[ -n "${SOPS_SECRET_FILES}" ]]; then
-  if [[ -n "${SOPS_KMS_ARN+x}" ]]; then
-    SOPS_OPTIONS="--kms ${SOPS_KMS_ARN}"
-  elif [[ -n "${SOPS_GCP_KMS_ID+x}" ]]; then
-    SOPS_OPTIONS="--gcp-kms ${SOPS_GCP_KMS_ID}"
-  else
-    echo SOPS_KMS_ARN or SOPS_GCP_KMS_ID must bet set to use SOPS_SECRET_FILES!
-    exit 1
-  fi
-fi


### PR DESCRIPTION
…th is recorded in the sops yml metadata and this is not necessary for decryption. key is required only when encrypting .. which we are not doing here