### PR TITLE
Adding a default helm value that can be consumed

### DIFF
--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -36,6 +36,7 @@ helm_upgrade() {
   helm upgrade --install "${CHART_RELEASE_NAME}" \
     "./deploy/${CHART_PATH}" -f "${CHART_VALUES}" \
     --set image.tag="${CI_SHA1}" \
+    --set appVersion="${CI_REF}" \
     --namespace="${NAMESPACE}" \
     --wait \
     --timeout "${HELM_TIMEOUTS[$index]:-$HELM_DEFAULT_TIMEOUT}" \

--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -36,7 +36,7 @@ helm_upgrade() {
   helm upgrade --install "${CHART_RELEASE_NAME}" \
     "./deploy/${CHART_PATH}" -f "${CHART_VALUES}" \
     --set image.tag="${CI_SHA1}" \
-    --set appVersion="${CI_REF}" \
+    --set rok8sCIRef="${CI_REF}" \
     --namespace="${NAMESPACE}" \
     --wait \
     --timeout "${HELM_TIMEOUTS[$index]:-$HELM_DEFAULT_TIMEOUT}" \


### PR DESCRIPTION
The intention is to be able to consume this helm chart value in a consistent way so that anyone can see what git ref was deployed into the cluster.

My recommendation will be to add a label to the pod like so:
```
metadata:
  labels:
    rok8sCIRef: {{ .Values.rok8sCIRef }}
spec:
  template:
    metadata:
      labels:
        app: {{ template "app.name" . }}
        release: {{ .Release.Name }}
        rok8sCIRef: {{ .Values.rok8sCIRef }}
```