### PR TITLE
removing --record flag from kubectl replace

### DIFF
--- a/bin/k8s-deploy
+++ b/bin/k8s-deploy
@@ -246,6 +246,6 @@ for index in "${!POD_DISRUPTION_BUDGET_FILES[@]}"
 do
   POD_DISRUPTION_BUDGET_FILE=${POD_DISRUPTION_BUDGET_FILES[$index]}
   echo "Replacing ${POD_DISRUPTION_BUDGET_FILE}"
-  kubectl replace --force --cascade -f ${POD_DISRUPTION_BUDGET_FILE} --namespace=$NAMESPACE --record
+  kubectl replace --force --cascade -f ${POD_DISRUPTION_BUDGET_FILE} --namespace=$NAMESPACE
 done
 echo "Done deploying Pod Disruption Budget"


### PR DESCRIPTION
The `--record` flag has been deprecated in `kubectl replace` 
See: https://github.com/kubernetes/kubernetes/issues/40422