### PR TITLE
Replacing "apply" with "replace" for encrypted secrets

### DIFF
--- a/bin/k8s-deploy-secrets
+++ b/bin/k8s-deploy-secrets
@@ -44,7 +44,7 @@ for SOPS_SECRET_FILE in "${SOPS_SECRET_FILES[@]}"
 do
   set -x
   sops ${SOPS_OPTIONS} --decrypt "${SOPS_SECRET_FILE}" | \
-  kubectl apply "--namespace=${NAMESPACE}" -f -
+  kubectl replace "--namespace=${NAMESPACE}" -f -
 done
 echo "Done deploying Encrypted Secrets"
 echo ""

--- a/examples/CircleCI-20/.circleci/config.yml
+++ b/examples/CircleCI-20/.circleci/config.yml
@@ -14,7 +14,7 @@ references:
 
   deploy_steps: &deploy_steps
     docker:
-      - image: quay.io/reactiveops/ci-images:v7.11.3-alpine
+      - image: quay.io/reactiveops/ci-images:v7.14.3-alpine
     steps:
       - checkout
       - *set_environment_variables
@@ -24,7 +24,7 @@ references:
 jobs:
   imagebuild:
     docker:
-      - image: quay.io/reactiveops/ci-images:v7.11.3-alpine
+      - image: quay.io/reactiveops/ci-images:v7.14.3-alpine
     steps:
       - checkout
       - setup_remote_docker

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.14.1'
+__version__ = '7.14.3'
 __author__ = 'ReactiveOps, Inc.'
 
 


### PR DESCRIPTION
Our usage of Sops encrypted secrets always represents the full state of a desired secret and thus we should be doing a full replace instead of a patch with apply. The patch behavior had undesired effects of setting a value to an empty string instead of fully unsetting it if it was removed from a secret in the deployment configuration. 