### PR TITLE
Adding kubeval to prevent secret values going to stdout

### DIFF
--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -120,3 +120,11 @@ if ! hash helm 2>/dev/null; then
   chmod +x "${ROK8S_INSTALL_PATH}/helm"
   rm -rf "${ROK8S_INSTALL_PATH}/helm-tmp"
 fi
+
+# make sure kubeval is installed
+if ! hash kubeval 2>/dev/null; then
+  echo Installing kubeval...
+  cd "${ROK8S_INSTALL_PATH}"
+  curl -L "https://github.com/garethr/kubeval/releases/download/0.7.3/kubeval-linux-amd64.tar.gz" | tar xzvf -
+  chmod +x "${ROK8S_INSTALL_PATH}/kubeval"
+fi

--- a/bin/k8s-deploy-secrets
+++ b/bin/k8s-deploy-secrets
@@ -43,8 +43,9 @@ echo "Deploying Encrypted Secrets"
 for SOPS_SECRET_FILE in "${SOPS_SECRET_FILES[@]}"
 do
   set -x
+  sops ${SOPS_OPTIONS} --decrypt "${SOPS_SECRET_FILE}" | kubeval
   sops ${SOPS_OPTIONS} --decrypt "${SOPS_SECRET_FILE}" | \
-  kubectl replace "--namespace=${NAMESPACE}" -f -
+    kubectl replace "--namespace=${NAMESPACE}" -f -
 done
 echo "Done deploying Encrypted Secrets"
 echo ""

--- a/bin/k8s-deploy-secrets
+++ b/bin/k8s-deploy-secrets
@@ -45,7 +45,7 @@ do
   set -x
   sops ${SOPS_OPTIONS} --decrypt "${SOPS_SECRET_FILE}" | kubeval
   sops ${SOPS_OPTIONS} --decrypt "${SOPS_SECRET_FILE}" | \
-    kubectl replace "--namespace=${NAMESPACE}" -f -
+  kubectl replace "--namespace=${NAMESPACE}" -f -
 done
 echo "Done deploying Encrypted Secrets"
 echo ""

--- a/examples/CircleCI-20/.circleci/config.yml
+++ b/examples/CircleCI-20/.circleci/config.yml
@@ -14,7 +14,7 @@ references:
 
   deploy_steps: &deploy_steps
     docker:
-      - image: quay.io/reactiveops/ci-images:v7.14.3-alpine
+      - image: quay.io/reactiveops/ci-images:v7.15.0-alpine
     steps:
       - checkout
       - *set_environment_variables
@@ -24,7 +24,7 @@ references:
 jobs:
   imagebuild:
     docker:
-      - image: quay.io/reactiveops/ci-images:v7.14.3-alpine
+      - image: quay.io/reactiveops/ci-images:v7.15.0-alpine
     steps:
       - checkout
       - setup_remote_docker

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.14.3'
+__version__ = '7.15.0'
 __author__ = 'ReactiveOps, Inc.'
 
 


### PR DESCRIPTION
When a secret is invalid, kubectl outputs the contents of that secret as a means of validation. That's less than ideal, so this PR adds kubeval validation as an intermediate step to try and avoid secrets getting output as a result of syntax errors. Here's a comparison of output before and after:

```
kubectl replace -f demo.secret.yaml
Error from server (BadRequest): error when replacing "demo.secret.yml": Secret in version "v1"
cannot be handled as a Secret: v1.Secret.StringData: ReadString: expects " or n, but found t, 
error found in #10 byte of ...|KEY":true,"NEXT_KEY|..., bigger context ...|:
"previous-value","KEY":true,"NEXT_KEY":"secret-value","|...
```

vs with kubeval:
```
kubeval demo.secret.yaml
The document demo.secret.yml contains an invalid Secret
---> stringData: Invalid type. Expected: [string,null], given: boolean
```