### PR TITLE
Adding the ability to retrieve secret values from AWS Secrets Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Your kubernetes API object files should all be stored in the /deploy top level d
 ### Monorepo support
 
 With rok8s-scripts, You can host and deploy a multitude of micro-services
-in one git repo (monorepo). Be sure to follow the directory structure defined above, 
+in one git repo (monorepo). Be sure to follow the directory structure defined above,
 e.g., `<repo>/deploy/<MicroserviceA>/<[Env]>/<app>.<extension>.yml`
 
 ## Credentials
@@ -190,6 +190,20 @@ In order to connect to a Kubernetes cluster the build must authenticate. In GKE 
 
 There are multiple ways to handle Kubernetes Secrets. Examples of each can be
 found in [here](examples/sops-secrets).
+
+### External Secrets Managers
+
+It is also possible to retrieve individual key/value pairs from an external secrets manager. Supported secret stores are:
+
+There are two ways to use this:
+* `. get-secrets` - this will allow you to use the variables as environment variables
+* As part of `k8s-deploy-secrets` when you set `EXTERNAL_SECRETS_K8S_NAME`.  This will create a secret in the k8s cluster with all of the secrets from the secret store that you listed.
+
+There is an example [here](examples/external-secrets-manager).
+
+External secrets managers supported:
+
+* AWS Secrets Manager - specify a list of AWS secret names to retrieve by setting `AWS_SECRETS`.
 
 ### Unencrypted
 
@@ -405,7 +419,7 @@ To generate a `KUBECONFIG_DATA` value you can use `cat ~/.kube/config | base64`.
 
 In some cases it will be beneficial to have an indicator of when a container that was built using the `docker-build` command actually created a new layer, as opposed to it just using cached layers.  There is a feature called `ROK8S_ENABLE_CHANGE_DETECTION` that can help with this.
 
-When set to `true`, `ROK8S_ENABLE_CHANGE_DETECTION` will compare the sha256 of the newly built container with the sha256 of the cached container for that branch.  It will output a file called `.changesDetected`.  This file will container `true` if there were changes, or `false` if the container ID is identical to the cache. 
+When set to `true`, `ROK8S_ENABLE_CHANGE_DETECTION` will compare the sha256 of the newly built container with the sha256 of the cached container for that branch.  It will output a file called `.changesDetected`.  This file will container `true` if there were changes, or `false` if the container ID is identical to the cache.
 
 # Releasing
 

--- a/bin/get-secrets
+++ b/bin/get-secrets
@@ -1,0 +1,20 @@
+#!/bin/bash
+# get-secrets
+
+. k8s-read-config
+
+EXTERNAL_SECRETS=()
+if [ -n "${AWS_SECRETS+x}" ]; then
+    echo "Getting AWS Secrets and setting environment variables"
+    for secret_name in "${AWS_SECRETS[@]}"
+    do
+        secret_json=$(aws secretsmanager get-secret-value --secret-id "$secret_name" --region "$AWS_REGION" | jq -r .SecretString)
+        for secret in $(echo "$secret_json" | jq -r "to_entries|map(\"\\(.key)=\\(.value|tostring)\")|.[]" ); do
+            echo "Setting ${secret%%=*}"
+            export "${secret?}"
+            EXTERNAL_SECRETS+=("$secret")
+        done
+    done
+fi
+
+

--- a/bin/k8s-deploy-secrets
+++ b/bin/k8s-deploy-secrets
@@ -9,6 +9,34 @@ then
   return 0
 fi
 
+echo "Getting external secrets"
+. get-secrets
+echo "Done getting external secrets"
+
+if [ -n "${EXTERNAL_SECRETS_K8S_NAME+x}" ]; then
+    echo "Creating ${EXTERNAL_SECRETS_K8S_NAME}"
+
+    read -r -d '' EXT_K8S_SECRET << EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${EXTERNAL_SECRETS_K8S_NAME}
+  namespace: ${NAMESPACE}
+data:
+EOF
+
+    for i in "${EXTERNAL_SECRETS[@]}"
+    do
+        read -r -d '' EXT_K8S_SECRET << EOF
+$EXT_K8S_SECRET
+  ${i%%=*}: $(echo -n "${i#*=}" | base64)
+EOF
+    done
+
+    kubectl replace -f <(echo "$EXT_K8S_SECRET") || kubectl create -f <(echo "$EXT_K8S_SECRET")
+    echo "Done creating external secrets"
+fi
+
 echo "Deploying Object Store Secrets"
 for EXTERNAL_SECRET_FILE in "${EXTERNAL_SECRET_FILES[@]}"
 do

--- a/examples/external-secrets-manager/circle.yml
+++ b/examples/external-secrets-manager/circle.yml
@@ -1,0 +1,28 @@
+machine:
+  environment:
+    PATH: $PATH:node_modules/.bin
+
+    CI_SHA1: $CIRCLE_SHA1
+    CI_BRANCH: $CIRCLE_BRANCH
+    CI_BUILD_NUM: $CIRCLE_BUILD_NUM
+    SOPS_GCP_KMS_ID: "projects/example-project/locations/global/keyRings/example-keyring/cryptoKeys/example-key"
+
+dependencies:
+  pre:
+    - npm install
+    - install-rok8s-requirements
+
+  override:
+    - echo "overriding inferred dependencies"
+
+test:
+  override:
+    - echo "overriding any inferred tests"
+
+deployment:
+  production:
+    branch: [master]
+    commands:
+      - install-rok8s-requirements
+      - prepare-kubectl
+      - k8s-deploy -f deploy/secrets.config

--- a/examples/external-secrets-manager/deploy/secrets.config
+++ b/examples/external-secrets-manager/deploy/secrets.config
@@ -1,0 +1,3 @@
+AWS_SECRETS=('common')
+EXTERNAL_SECRETS_K8S_NAME='external-secrets'
+NAMESPACE='deploynamespace'

--- a/examples/external-secrets-manager/package.json
+++ b/examples/external-secrets-manager/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "example",
+  "version": "0.0.0",
+  "description": "Example app deployment with rok8s-scripts",
+  "repository": {
+    "type": "git",
+    "url": "+https://github.com/reactiveops/rok8s-scripts.git"
+  },
+  "author": "ReactiveOps",
+  "license": "Apache-2.0",
+  "dependencies": {
+     "rok8s-scripts": "*"
+  }
+}
+

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.18.1'
+__version__ = '7.19.0'
 __author__ = 'ReactiveOps, Inc.'
 
 


### PR DESCRIPTION
This will allow a pattern of adding external secret stores in general.  Adds a file called `get-secrets` that will be a place to keep functions for retrieving external secrets and exporting them. 

Could also be used to generally retrieve secrets by sourcing the get-secrets function.

Can be used to create a k8s secret that has all of the external secrets by setting:
```
EXTERNAL_SECRETS_K8S_NAME='external-secrets'
NAMESPACE=letsmakesecrets
```