### PR TITLE
Use --from-literal to create external secrets

### DIFF
--- a/bin/k8s-deploy-secrets
+++ b/bin/k8s-deploy-secrets
@@ -14,28 +14,18 @@ echo "Getting external secrets"
 echo "Done getting external secrets"
 
 if [ -n "${EXTERNAL_SECRETS_K8S_NAME+x}" ]; then
-    echo "Creating ${EXTERNAL_SECRETS_K8S_NAME}"
+  KUBECTL_ARGS=""
+  for i in "${EXTERNAL_SECRETS[@]}"
+  do
+    KUBECTL_ARGS+=" --from-literal=$1"
+  done
 
-    read -r -d '' EXT_K8S_SECRET << EOF
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ${EXTERNAL_SECRETS_K8S_NAME}
-  namespace: ${NAMESPACE}
-data:
-EOF
-
-    for i in "${EXTERNAL_SECRETS[@]}"
-    do
-        read -r -d '' EXT_K8S_SECRET << EOF
-$EXT_K8S_SECRET
-  ${i%%=*}: $(echo -n "${i#*=}" | base64)
-EOF
-    done
-
-    kubectl replace -f <(echo "$EXT_K8S_SECRET") || kubectl create -f <(echo "$EXT_K8S_SECRET")
-    echo "Done creating external secrets"
+  eval kubectl create secret generic $EXTERNAL_SECRETS_K8S_NAME --namespace=$NAMESPACE $KUBECTL_ARGS --dry-run -o yaml | kubectl apply -f -
 fi
+
+
+
+
 
 echo "Deploying Object Store Secrets"
 for EXTERNAL_SECRET_FILE in "${EXTERNAL_SECRET_FILES[@]}"

--- a/bin/k8s-deploy-secrets
+++ b/bin/k8s-deploy-secrets
@@ -14,16 +14,16 @@ echo "Getting external secrets"
 echo "Done getting external secrets"
 
 if [ -n "${EXTERNAL_SECRETS_K8S_NAME+x}" ]; then
+  echo "Creating ${EXTERNAL_SECRETS_K8S_NAME}"
   KUBECTL_ARGS=""
   for i in "${EXTERNAL_SECRETS[@]}"
   do
-    KUBECTL_ARGS+=" --from-literal=$1"
+    KUBECTL_ARGS+=" --from-literal=$i"
   done
 
   eval kubectl create secret generic $EXTERNAL_SECRETS_K8S_NAME --namespace=$NAMESPACE $KUBECTL_ARGS --dry-run -o yaml | kubectl apply -f -
+  echo "Done creating external secrets"
 fi
-
-
 
 
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "docker-push": "./bin/docker-push",
     "docker-resolve": "./bin/docker-resolve",
     "get-remote-kubecfg": "./bin/get-remote-kubecfg",
+    "get-secrets": "./bin/get-secrets",
     "helm-deploy": "./bin/helm-deploy",
     "helm-template": "./bin/helm-template",
     "install-rok8s-requirements": "./bin/install-rok8s-requirements",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rok8s-scripts",
-  "version": "7.20.0",
+  "version": "7.19.1",
   "description": "Bash scripts for deploying and managing applications in Kubernetes",
   "bin": {
     "decrypt-kubecfg": "./bin/decrypt-kubecfg",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rok8s-scripts",
-  "version": "0.0.1",
+  "version": "7.20.0",
   "description": "Bash scripts for deploying and managing applications in Kubernetes",
   "bin": {
     "decrypt-kubecfg": "./bin/decrypt-kubecfg",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.20.0'
+__version__ = '7.19.1'
 __author__ = 'ReactiveOps, Inc.'
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.19.0'
+__version__ = '7.20.0'
 __author__ = 'ReactiveOps, Inc.'
 
 


### PR DESCRIPTION
I ran into an issue with the alpine ci image not correctly parsing the here-docs when generating external secrets.  i updated the logic to create the secret using `--from-literal` directives:

```
kubectl create secret generic foo-secret --namespace=foo-namespace --from-literal=foo=bar --dry-run -o yaml | kubectl apply -f -
```

I also added  `get-secrets` to the package.json manifest.