### PR TITLE
Tiller support in non-default namespaces

### DIFF
--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -17,6 +17,14 @@ if [[ ! $(kubectl get namespace $NAMESPACE) ]]; then
   kubectl create namespace $NAMESPACE;
 fi
 
+# Set tiller_namespace if it isn't already set.
+# Allows us to use helm even if it's not installed
+# in kube-system.
+if [ -z "$TILLER_NAMESPACE" ]; then
+  TILLER_NAMESPACE="$(kubectl get deploy -o wide --all-namespaces | grep tiller-deploy | tail -n 1 | cut -d ' ' -f 1 | tr -d ' ')"
+  echo "Set tiller namespace to $TILLER_NAMESPACE"
+fi
+
 # If using k8s-deploy in combination with helm-deploy
 #  while transitioning to helm, set this to avoid deploying
 #  secrets twice

--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -21,7 +21,10 @@ fi
 # Allows us to use helm even if it's not installed
 # in kube-system.
 if [ -z "$TILLER_NAMESPACE" ]; then
-  TILLER_NAMESPACE="$(kubectl get deploy -o wide --all-namespaces | grep tiller-deploy | tail -n 1 | cut -d ' ' -f 1 | tr -d ' ')"
+  TILLER_NAMESPACE="$(kubectl get deploy --all-namespaces -l app=helm,name=tiller | tail -n 1 | cut -d ' ' -f 1 | tr -d ' ')"
+
+  # just in case variable didn't get set, give it a default
+  TILLER_NAMESPACE=${TILLER_NAMESPACE:-kube-system}
   echo "Set tiller namespace to $TILLER_NAMESPACE"
 fi
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rok8s-scripts",
-  "version": "7.19.1",
+  "version": "7.20.0",
   "description": "Bash scripts for deploying and managing applications in Kubernetes",
   "bin": {
     "decrypt-kubecfg": "./bin/decrypt-kubecfg",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.19.1'
+__version__ = '7.20.0'
 __author__ = 'ReactiveOps, Inc.'
 
 


### PR DESCRIPTION
This PR sets the `TILLER_NAMESPACE` variable if it's not already set.  This allows `helm-deploy` to work if tiller is not installed in `kube-system` and the variable isn't set.