### PR TITLE
Fixing links in docs for github pages

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -55,7 +55,7 @@ somevalue: anothervalue
 
 ## Secret Management
 
-Helm stores release information in Config Maps. If we deployed Kubernetes Secrets with Helm, they'd also be visible in that Helm release Config Map. To avoid that, we manage secrets separately. Please see [Managing Kubernetes Secrets Securely](/docs/secrets.md) for further information.
+Helm stores release information in Config Maps. If we deployed Kubernetes Secrets with Helm, they'd also be visible in that Helm release Config Map. To avoid that, we manage secrets separately. Please see [Managing Kubernetes Secrets Securely](secrets.md) for further information.
 
 ## Deploying it All
 
@@ -69,7 +69,7 @@ helm-deploy -f deploy/development.config
 
 This script reads the rok8s-scripts config file (`deploy/development.config`) and runs a Helm upgrade or install with the given values files.
 
-Importantly, it will set the `image.tag` value to `CI_SHA1`, a value that should match the tag of your latest pushed image. There's more info available in our [Docker documentation](/docs/docker.md) on how these images are tagged and pushed.
+Importantly, it will set the `image.tag` value to `CI_SHA1`, a value that should match the tag of your latest pushed image. There's more info available in our [Docker documentation](docker.md) on how these images are tagged and pushed.
 
 ## Templating
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,30 +12,30 @@ The latest Debian Stretch release can be pulled from `quay.io/reactiveops/ci-ima
 
 ## Examples
 
-rok8s-scripts is designed to work well in a wide variety of environments. That includes Bitbucket Pipelines, CircleCI, GitLab CI, and more. There are many valid ways to configure CI pipelines, we've includes a variety of [examples](/examples) in this repository.
+rok8s-scripts is designed to work well in a wide variety of environments. That includes Bitbucket Pipelines, CircleCI, GitLab CI, and more. There are many valid ways to configure CI pipelines, we've includes a variety of [examples](https://github.com/reactiveops/rok8s-scripts/tree/master/examples) in this repository.
 
 Most notably, the CI example includes sample configuration for the following platforms:
 
-- [Bitbucket Pipelines](/examples/ci/bitbucket-pipelines.yml)
-- [CircleCI](/examples/ci/.circleci/config.yml)
-- [GitLab CI](/examples/ci/.gitlab-ci.yml)
-- [Jenkins](/examples/ci/Jenkinsfile)
+- [Bitbucket Pipelines](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/ci/bitbucket-pipelines.yml)
+- [CircleCI](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/ci/.circleci/config.yml)
+- [GitLab CI](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/ci/.gitlab-ci.yml)
+- [Jenkins](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/ci/Jenkinsfile)
 
 On their own, these examples may not make a lot of sense. There's a lot more documentation below that should cover everything included in these examples and more.
 
 ## Further Reading
 
-- [Building and Pushing Docker Images](/docs/docker.md)
-- [Deploying to Kubernetes with Helm](/docs/helm.md)
-- [Deploying to Kubernetes without Helm](/docs/without_helm.md)
-- [Managing Kubernetes Secrets Securely](/docs/secrets.md)
+- [Building and Pushing Docker Images](docker.md)
+- [Deploying to Kubernetes with Helm](helm.md)
+- [Deploying to Kubernetes without Helm](without_helm.md)
+- [Managing Kubernetes Secrets Securely](secrets.md)
 
 ### Cloud Specific Documentation
-- [Amazon Web Services](/docs/aws.md)
-- [Google Cloud](/docs/gcp.md)
+- [Amazon Web Services](aws.md)
+- [Google Cloud](gcp.md)
 
 ### Contributing
-- [Releasing New Versions of rok8s-scripts](/docs/releasing.md)
+- [Releasing New Versions of rok8s-scripts](releasing.md)
 
 ## License
 Apache License 2.0

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -10,7 +10,7 @@ There are two ways to use this:
 * `. get-secrets` - this will allow you to use the variables as environment variables
 * As part of `k8s-deploy-secrets` when you set `EXTERNAL_SECRETS_K8S_NAME`.  This will create a secret in the k8s cluster with all of the secrets from the secret store that you listed.
 
-There is an example [here](/examples/external-secrets-manager).
+There is an example [here](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/external-secrets-manager).
 
 ## Encrypted Secrets With Sops
 Sops and rok8s-scripts can provide a powerful solution to encrypted secret management. This enables you to keep your secrets in source control and track changes to those secrets along with the rest of your Kubernetes configuration. All of this is powered with cloud based KMS from either AWS or GCP. To access secrets, users need access to both your Git repository and appropriate IAM credentials for KMS.
@@ -19,7 +19,7 @@ Using an [AWS KMS](https://aws.amazon.com/kms/) ARN or [Google KMS](https://clou
 
 Whenever encrypting data, `sops` requires credentials for the appropriate
 cloud provider (GCP or AWS). You can read more about `sops` usage [here](https://github.com/mozilla/sops#usage). Full examples of sops usage with rok8s-scripts can be
-[found here](/examples/sops-secrets).
+[found here](https://github.com/reactiveops/rok8s-scripts/tree/master/examples/sops-secrets).
 
 The examples below will use GCP KMS, but the process is very similar when using AWS KMS.
 

--- a/docs/without_helm.md
+++ b/docs/without_helm.md
@@ -1,5 +1,5 @@
 # Deploying to Kubernetes without Helm
-Although [Helm](/docs/helm.md) is our preferred method of deploying to Kubernetes, rok8s-scripts also supports deploying to Kubernetes without Helm.
+Although [Helm](helm.md) is our preferred method of deploying to Kubernetes, rok8s-scripts also supports deploying to Kubernetes without Helm.
 
 ## Initial Project Structure
 All rok8s-scripts configuration lives in a `deploy` directory at the root of your project by default. In this example, we have a simple Python app with a Dockerfile in place.
@@ -44,7 +44,7 @@ This full configuration could be deployed with the following rok8s-scripts comma
 k8s-deploy-and-verify -f deploy/development.config
 ```
 
-More indepth examples are available in the [examples directory](/examples).
+More indepth examples are available in the [examples directory](https://github.com/reactiveops/rok8s-scripts/tree/master/examples).
 
 ## Versioning
 **If a Docker image is used in the file then any cases of `:latest` will be replaced with th `CI_SHA1` if it is defined.** This allows a set image tag to be used when deploying from a CI system. When files that could use `CI_SHA1` are deployed, a new file will be created with that value as part of the filename.


### PR DESCRIPTION
Although the markdown links worked fine outside of the context of GitHub pages, they fell apart in GitHub pages. This should help links work everywhere.