### PR TITLE
Make docker-push "latest" suffix configurable & support arbitrary docker tag versions

### DIFF
--- a/bin/docker-build
+++ b/bin/docker-build
@@ -10,6 +10,9 @@ if [ -z "$DOCKERFILE" ]; then echo DOCKERFILE must be set; exit 1; fi
 PREVIOUS_COMMIT=$(git rev-parse HEAD~1)
 CI_BRANCH=$(echo "${CI_BRANCH}" | tr / _)
 
+# support overriding "latest"
+DOCKER_LATEST_TAG=${DOCKER_LATEST_TAG:-latest}
+
 if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
   echo "Using --cache-from to improve performance"
 
@@ -46,7 +49,7 @@ if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
     DOCKER_TARGET="--target=${DOCKER_TARGET}"
   fi
   # shellcheck disable=2086
-  docker build --rm=false -t "${DOCKERTAG}" -f "${BASEDIR}/${DOCKERFILE}" \
+  docker build --rm=false -t "${DOCKERTAG}:${DOCKER_LATEST_TAG}" -f "${BASEDIR}/${DOCKERFILE}" \
     ${CACHE_FROM_TARGETS} \
     ${DOCKER_TARGET} \
     ${ROK8S_DOCKER_BUILD_EXTRAARGS} \
@@ -57,7 +60,7 @@ if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
 else
   echo "--cache-from not available with this version of Docker"
   # shellcheck disable=2086
-  docker build --rm=false -t "${DOCKERTAG}" -f "${BASEDIR}/${DOCKERFILE}" ${ROK8S_DOCKER_BUILD_EXTRAARGS} "${BASEDIR}"
+  docker build --rm=false -t "${DOCKERTAG}:${DOCKER_LATEST_TAG}" -f "${BASEDIR}/${DOCKERFILE}" ${ROK8S_DOCKER_BUILD_EXTRAARGS} "${BASEDIR}"
 fi
 # shellcheck disable=2181
 if [ $? -ne 0 ]
@@ -70,9 +73,6 @@ if [ "$ROK8S_ENABLE_CHANGE_DETECTION" ]; then
   #Check to see if the digest for this image has changed.  If it has not, then indicate that
   printf "\\nRunning change detection...\\n"
   oldDigest=$(docker inspect "${EXTERNAL_REGISTRY_BASE_DOMAIN}"/"${REPOSITORY_NAME}":"$CI_BRANCH" | jq -r .[].Id)
-
-  # support overriding "latest"
-  DOCKER_LATEST_TAG=${DOCKER_LATEST_TAG:-latest}
 
   newDigest=$(docker inspect "${EXTERNAL_REGISTRY_BASE_DOMAIN}"/"${REPOSITORY_NAME}":"${DOCKER_LATEST_TAG}" | jq -r .[].Id)
 

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -70,7 +70,11 @@ if [ "$ROK8S_ENABLE_CHANGE_DETECTION" ]; then
   #Check to see if the digest for this image has changed.  If it has not, then indicate that
   printf "\\nRunning change detection...\\n"
   oldDigest=$(docker inspect "${EXTERNAL_REGISTRY_BASE_DOMAIN}"/"${REPOSITORY_NAME}":"$CI_BRANCH" | jq -r .[].Id)
-  newDigest=$(docker inspect "${EXTERNAL_REGISTRY_BASE_DOMAIN}"/"${REPOSITORY_NAME}":latest | jq -r .[].Id)
+
+  # support overriding "latest"
+  DOCKER_LATEST_TAG=${DOCKER_LATEST_TAG:-latest}
+
+  newDigest=$(docker inspect "${EXTERNAL_REGISTRY_BASE_DOMAIN}"/"${REPOSITORY_NAME}":"${DOCKER_LATEST_TAG}" | jq -r .[].Id)
 
   changeFile=".changesDetected"
   if [ -f $changeFile ]; then

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -20,10 +20,18 @@ if [ -z "$CI_REF" ]; then echo CI_BRANCH or CI_TAG must be set; exit 1; fi
 
 CI_REF=$(echo "${CI_REF}" | tr / _)
 
-# support list of additional tag versions delimited by commas by default
-DOCKER_TAG_VERSION_DELIMITER_CHAR="${DOCKER_TAG_VERSION_DELIMITER_CHAR:-,}"
+# support list of tag versions
 BUILD_TAG_PREFIX=${BUILD_TAG_PREFIX:-build_}
-TAG_VERSIONS="${TAG_VERSIONS:-$CI_SHA1$TAG_VERSION_DELIMITER_CHAR$CI_REF$TAG_VERSION_DELIMITER_CHAR$BUILD_TAG_PREFIX$CI_BUILD_NUM}"
+if [ -z "$DOCKER_TAG_VERSIONS" ]; then
+  DOCKER_TAG_VERSIONS=("$CI_SHA1" "$CI_REF" "$BUILD_TAG_PREFIX$CI_BUILD_NUM")
+fi
+
+# check for additional tags
+if [ -z "$ADDITONAL_DOCKER_TAG_VERSIONS" ]; then
+  ADDITIONAL_DOCKER_TAG_VERSIONS=()
+fi
+
+ALL_DOCKER_TAG_VERSIONS=(${DOCKER_TAG_VERSIONS[@]} ${ADDITIONAL_DOCKER_TAG_VERSIONS[@]})
 
 tag_push() {
   if ! docker tag "$1" "$2"
@@ -49,9 +57,9 @@ if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
   done <<< "$(grep -i '^FROM.* AS ' ${DOCKERFILE} | awk '{print $4}')"
 fi
 
-for TAG_VERSION in $(echo "$TAG_VERSIONS" | tr "$DOCKER_TAG_VERSION_DELIMITER_CHAR" ' '); do
-  if [ "${DOCKER_LATEST_TAG}" != "${TAG_VERSION}" ]; then
-    echo "Pushing ${DOCKERTAG}:${DOCKER_LATEST_TAG} as ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${TAG_VERSION}"
-    tag_push "${DOCKERTAG}:${DOCKER_LATEST_TAG}" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${TAG_VERSION}"
+for DOCKER_TAG_VERSION in ${ALL_DOCKER_TAG_VERSIONS[@]}; do
+  if [ "${DOCKER_LATEST_TAG}" != "${DOCKER_TAG_VERSION}" ]; then
+    echo "Pushing ${DOCKERTAG}:${DOCKER_LATEST_TAG} as ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${DOCKER_TAG_VERSION}"
+    tag_push "${DOCKERTAG}:${DOCKER_LATEST_TAG}" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${DOCKER_TAG_VERSION}"
   fi
 done

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -10,7 +10,7 @@ if [ -z "$CI_SHA1" ];                       then echo CI_SHA1 must be set; exit 
 if [ -z "$CI_BUILD_NUM" ];                  then echo CI_BUILD_NUM must be set; exit 1; fi
 
 # support overriding "latest"
-LATEST=${LATEST:-latest}
+DOCKER_LATEST_TAG=${DOCKER_LATEST_TAG:-latest}
 
 # Set a CI_REF from branch or tag
 CI_REF="${CI_TAG}"
@@ -21,7 +21,7 @@ if [ -z "$CI_REF" ]; then echo CI_BRANCH or CI_TAG must be set; exit 1; fi
 CI_REF=$(echo "${CI_REF}" | tr / _)
 
 # support list of additional tag versions delimited by commas by default
-TAG_VERSION_DELIMITER_CHAR="${TAG_VERSION_DELIMITER_CHAR:-,}"
+DOCKER_TAG_VERSION_DELIMITER_CHAR="${DOCKER_TAG_VERSION_DELIMITER_CHAR:-,}"
 BUILD_TAG_PREFIX=${BUILD_TAG_PREFIX:-build_}
 TAG_VERSIONS="${TAG_VERSIONS:-$CI_SHA1$TAG_VERSION_DELIMITER_CHAR$CI_REF$TAG_VERSION_DELIMITER_CHAR$BUILD_TAG_PREFIX$CI_BUILD_NUM}"
 
@@ -49,9 +49,9 @@ if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
   done <<< "$(grep -i '^FROM.* AS ' ${DOCKERFILE} | awk '{print $4}')"
 fi
 
-for TAG_VERSION in $(echo "$TAG_VERSIONS" | tr "$TAG_VERSION_DELIMITER_CHAR" ' '); do
-  if [ "${LATEST}" != "${TAG_VERSION}" ]; then
-    echo "Pushing ${DOCKERTAG}:${LATEST} as ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${TAG_VERSION}"
-    tag_push "${DOCKERTAG}:${LATEST}" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${TAG_VERSION}"
+for TAG_VERSION in $(echo "$TAG_VERSIONS" | tr "$DOCKER_TAG_VERSION_DELIMITER_CHAR" ' '); do
+  if [ "${DOCKER_LATEST_TAG}" != "${TAG_VERSION}" ]; then
+    echo "Pushing ${DOCKERTAG}:${DOCKER_LATEST_TAG} as ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${TAG_VERSION}"
+    tag_push "${DOCKERTAG}:${DOCKER_LATEST_TAG}" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${TAG_VERSION}"
   fi
 done

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -9,6 +9,9 @@ if [ -z "$DOCKERTAG" ];                     then echo DOCKERTAG must be set; exi
 if [ -z "$CI_SHA1" ];                       then echo CI_SHA1 must be set; exit 1; fi
 if [ -z "$CI_BUILD_NUM" ];                  then echo CI_BUILD_NUM must be set; exit 1; fi
 
+# support overriding "latest"
+LATEST=${LATEST:-latest}
+
 # Set a CI_REF from branch or tag
 CI_REF="${CI_TAG}"
 CI_REF="${CI_REF:-$CI_BRANCH}"
@@ -16,6 +19,11 @@ CI_REF="${CI_REF:-$CI_BRANCH}"
 if [ -z "$CI_REF" ]; then echo CI_BRANCH or CI_TAG must be set; exit 1; fi
 
 CI_REF=$(echo "${CI_REF}" | tr / _)
+
+# support list of additional tag versions delimited by commas by default
+TAG_VERSION_DELIMITER_CHAR="${TAG_VERSION_DELIMITER_CHAR:-,}"
+BUILD_TAG_PREFIX=${BUILD_TAG_PREFIX:-build_}
+TAG_VERSIONS="${TAG_VERSIONS:-$CI_SHA1$TAG_VERSION_DELIMITER_CHAR$CI_REF$TAG_VERSION_DELIMITER_CHAR$BUILD_TAG_PREFIX$CI_BUILD_NUM}"
 
 tag_push() {
   if ! docker tag "$1" "$2"
@@ -41,8 +49,9 @@ if [ "$DOCKER_BUILD_CACHE_FROM" == "available" ]; then
   done <<< "$(grep -i '^FROM.* AS ' ${DOCKERFILE} | awk '{print $4}')"
 fi
 
-echo "Pushing ${DOCKERTAG}:latest as ${CI_SHA1}, ${CI_REF}, ${CI_BUILD_NUM} to ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}"
-
-tag_push "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_SHA1}"
-tag_push "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${CI_REF}"
-tag_push "${DOCKERTAG}:latest" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:build_${CI_BUILD_NUM}"
+for TAG_VERSION in $(echo "$TAG_VERSIONS" | tr "$TAG_VERSION_DELIMITER_CHAR" ' '); do
+  if [ "${LATEST}" != "${TAG_VERSION}" ]; then
+    echo "Pushing ${DOCKERTAG}:${LATEST} as ${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${TAG_VERSION}"
+    tag_push "${DOCKERTAG}:${LATEST}" "${EXTERNAL_REGISTRY_BASE_DOMAIN}/${REPOSITORY_NAME}:${TAG_VERSION}"
+  fi
+done

--- a/bin/docker-push
+++ b/bin/docker-push
@@ -22,12 +22,12 @@ CI_REF=$(echo "${CI_REF}" | tr / _)
 
 # support list of tag versions
 BUILD_TAG_PREFIX=${BUILD_TAG_PREFIX:-build_}
-if [ -z "$DOCKER_TAG_VERSIONS" ]; then
+if [ -z "${DOCKER_TAG_VERSIONS[@]}" ]; then
   DOCKER_TAG_VERSIONS=("$CI_SHA1" "$CI_REF" "$BUILD_TAG_PREFIX$CI_BUILD_NUM")
 fi
 
 # check for additional tags
-if [ -z "$ADDITONAL_DOCKER_TAG_VERSIONS" ]; then
+if [ -z "${ADDITONAL_DOCKER_TAG_VERSIONS[@]}" ]; then
   ADDITIONAL_DOCKER_TAG_VERSIONS=()
 fi
 

--- a/bin/docker-save
+++ b/bin/docker-save
@@ -30,6 +30,9 @@ image_save() {
 
 }
 
-echo "Exporting ${DOCKERTAG}:latest to ${OUTPUT_FILE}"
-image_save "${DOCKERTAG}:latest" "${OUTPUT_FILE}"
+# support overriding "latest"
+DOCKER_LATEST_TAG=${DOCKER_LATEST_TAG:-latest}
+
+echo "Exporting ${DOCKERTAG}:${DOCKER_LATEST_TAG} to ${OUTPUT_FILE}"
+image_save "${DOCKERTAG}:${DOCKER_LATEST_TAG}" "${OUTPUT_FILE}"
 echo "Finished export of ${OUTPUT_FILE}"

--- a/bin/docker-save
+++ b/bin/docker-save
@@ -14,7 +14,7 @@ while getopts ":f:o:" opt; do
   esac
 done
 
-if [ -z "$OUTPUT_FILE" ];                   then echo "OUTPUT_FILE not specificed, must use -o"; exit 1; fi
+if [ -z "$OUTPUT_FILE" ];                   then echo "OUTPUT_FILE not specified, must use -o"; exit 1; fi
 
 . k8s-read-config -f "$CONFIG_FILE"
 . docker-resolve


### PR DESCRIPTION
We don't use `latest` normally, so we needed to make this script more flexible, supporting a configurable `latest` tag version, as well as allowing the caller to specify all additional tag versions that should be pushed.

All behavior is backwards compatible.