### PR TITLE
Explicitly set --tiller-namespace flag

### DIFF
--- a/bin/helm-deploy
+++ b/bin/helm-deploy
@@ -55,6 +55,7 @@ helm_upgrade() {
     --set image.tag="${CI_SHA1}" \
     --set rok8sCIRef="${CI_REF}" \
     --namespace="${NAMESPACE}" \
+    --tiller-namespace="${TILLER_NAMESPACE}" \
     --wait \
     --timeout "${HELM_TIMEOUTS[$index]:-$HELM_DEFAULT_TIMEOUT}" \
       2>&1 | tee "${ROK8S_TMP}/helm.out"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rok8s-scripts",
-  "version": "7.20.0",
+  "version": "7.20.1",
   "description": "Bash scripts for deploying and managing applications in Kubernetes",
   "bin": {
     "decrypt-kubecfg": "./bin/decrypt-kubecfg",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except ImportError:
           "pip install setuptools).")
     sys.exit(1)
 
-__version__ = '7.20.0'
+__version__ = '7.20.1'
 __author__ = 'ReactiveOps, Inc.'
 
 


### PR DESCRIPTION
Some helm versions are not honoring the `TILLER_NAMESPACE` environment variable.  I explicitly set the `--tiller-namespace` flag with the `helm upgrade` command so the namespace still gets passed to the helm client correctly.