### PR TITLE
Install docker-compose in alpine ci-image

### DIFF
--- a/ci-images/alpine/Dockerfile
+++ b/ci-images/alpine/Dockerfile
@@ -2,7 +2,8 @@ FROM docker:18
 
 USER root
 
-RUN apk add --update --no-cache jq wget py-pip curl bash git openssh-client
+RUN apk add --update --no-cache jq wget py-pip curl bash git openssh-client \
+    && pip install --no-cache-dir --disable-pip-version-check docker-compose
 
 COPY bin /usr/local/bin
 RUN install-rok8s-requirements


### PR DESCRIPTION
This commit adds a pip install line to make docker-compose available in the alpine image (as it exists in stretch).