### PR TITLE
Update Helm Version in CI-Image

### DIFF
--- a/bin/install-rok8s-requirements
+++ b/bin/install-rok8s-requirements
@@ -33,7 +33,7 @@ else
 fi
 
 KUBECTL_VERSION="${KUBECTL_VERSION:-v1.11.6}"
-HELM_VERSION="${HELM_VERSION:-v2.12.2}"
+HELM_VERSION="${HELM_VERSION:-v2.13.0}"
 SOPS_VERSION="${SOPS_VERSION:-3.0.5}"
 
 # make sure sudo is installed


### PR DESCRIPTION
New helm version which adds some awesome features like `--atomic` flag for safer deploys.

*edit* CI fail is something to do with credentials :(